### PR TITLE
feat: export template variables as structured JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,18 @@ uv sync --dev
 ## Python API
 
 ```python
-from docthu import parse, Template
+from docthu import parse, Template, variables
 
-# One-shot
+# One-shot extraction
 result = parse(template_str, message_str)
 
 # Reusable (template compiled once, matched many times)
 tpl = Template(template_str)
 result = tpl.match(message_str)
+
+# Inspect the variable schema of a template
+schema = variables(template_str)   # standalone, one-shot
+schema = tpl.variables()           # or on a compiled Template
 ```
 
 ### Template syntax
@@ -143,6 +147,38 @@ except CoercionError as e:
     # Extracted value couldn't be coerced to the declared type
     print(e.var_name, e.raw_value, e.target_type)
 ```
+
+### Exporting the variable schema
+
+`variables()` returns the list of variables declared in a template as JSON-serialisable dicts, without running an extraction. Useful for generating UI schemas, validating template coverage, or storing template metadata.
+
+```python
+from docthu import variables, Template
+
+template = """\
+Date: {{ date }}
+Amount: {{ amount:float }}
+{% sender.bank_name = 'Vietcombank' %}
+"""
+
+variables(template)
+# [
+#   {"name": "date",             "type": "str",   "execution": "extract"},
+#   {"name": "amount",           "type": "float", "execution": "extract"},
+#   {"name": "sender.bank_name", "type": "str",   "execution": "static_assign", "value": "Vietcombank"},
+# ]
+```
+
+Each entry contains:
+
+| Field | Values | Description |
+|---|---|---|
+| `name` | dotted path string | Variable name as declared in the template |
+| `type` | `str`, `int`, `float`, `date`, `datetime` | Coercion type |
+| `execution` | `extract` \| `static_assign` | `extract` for `{{ var }}` tokens; `static_assign` for `{% var = 'value' %}` tokens |
+| `value` | string | Present only when `execution == "static_assign"` — the literal assigned value |
+
+Items are returned in document order. The result is always `json.dumps()`-safe.
 
 ## Use cases
 

--- a/docthu/__init__.py
+++ b/docthu/__init__.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 from .coercion import CoercionError
 from .matcher import MatchError, extract
-from .tokenizer import TemplateParseError, tokenize
+from .tokenizer import AssignmentToken, TemplateParseError, VariableToken, tokenize
 
 __all__ = [
     "Template",
     "parse",
+    "variables",
     "TemplateParseError",
     "MatchError",
     "CoercionError",
@@ -47,6 +48,23 @@ class Template:
         self._tokens = tokenize(template)
         self._flexible = flexible
 
+    def variables(self) -> list[dict]:
+        """
+        Return the variables defined in this template as a list of dicts.
+
+        Each dict has the keys:
+
+        - ``name``      — dotted variable name
+        - ``type``      — coercion type (``"str"``, ``"int"``, ``"float"``,
+          ``"date"``, ``"datetime"``)
+        - ``execution`` — ``"extract"`` for ``{{ var }}`` tokens or
+          ``"static_assign"`` for ``{% var = 'value' %}`` tokens
+        - ``value``     — present only when ``execution == "static_assign"``
+
+        Items are returned in template (document) order.
+        """
+        return _variables(self._tokens)
+
     def match(self, message: str) -> dict:
         """
         Extract variables from *message* using this template.
@@ -57,6 +75,25 @@ class Template:
         Raises :class:`CoercionError` if a typed variable can't be converted.
         """
         return extract(self._tokens, message, flexible=self._flexible)
+
+
+def _variables(tokens) -> list[dict]:
+    result = []
+    for token in tokens:
+        if isinstance(token, VariableToken):
+            result.append({"name": token.name, "type": token.type, "execution": "extract"})
+        elif isinstance(token, AssignmentToken):
+            result.append({"name": token.name, "type": "str", "execution": "static_assign", "value": token.value})
+    return result
+
+
+def variables(template: str) -> list[dict]:
+    """
+    Return the variables defined in *template* as a list of dicts.
+
+    Convenience wrapper around ``Template.variables()`` for one-shot use.
+    """
+    return _variables(tokenize(template))
 
 
 def parse(template: str, message: str, *, flexible: bool = True) -> dict:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,7 +7,7 @@ from datetime import date
 
 import pytest
 
-from docthu import CoercionError, MatchError, Template, TemplateParseError, parse
+from docthu import CoercionError, MatchError, Template, TemplateParseError, parse, variables
 
 
 # ---------------------------------------------------------------------------
@@ -226,3 +226,55 @@ def test_trailing_dot_newline_no_whitespace_after_dot():
     message = "vào ngày 22/03/2026.<br> <br> Regards, on 22/03/2026."
     result = parse(template, message, flexible=True)
     assert result["occurred_at"] == date(2026, 3, 22)
+
+
+# ---------------------------------------------------------------------------
+# 12. variables() — export template variable schema
+# ---------------------------------------------------------------------------
+
+def test_variables_extract_only():
+    tpl = "Date: {{ date }} Amount: {{ amount:float }}"
+    result = variables(tpl)
+    assert result == [
+        {"name": "date", "type": "str", "execution": "extract"},
+        {"name": "amount", "type": "float", "execution": "extract"},
+    ]
+
+
+def test_variables_static_assign_only():
+    tpl = "{% sender.bank_name = 'Vietcombank' %}\nHello"
+    result = variables(tpl)
+    assert result == [
+        {"name": "sender.bank_name", "type": "str", "execution": "static_assign", "value": "Vietcombank"},
+    ]
+
+
+def test_variables_mixed():
+    tpl = "Date: {{ date }}\n{% sender.bank_name = 'Vietcombank' %}\nAmount: {{ amount:float }}"
+    result = variables(tpl)
+    assert result == [
+        {"name": "date", "type": "str", "execution": "extract"},
+        {"name": "sender.bank_name", "type": "str", "execution": "static_assign", "value": "Vietcombank"},
+        {"name": "amount", "type": "float", "execution": "extract"},
+    ]
+
+
+def test_variables_document_order():
+    tpl = "{{ b }} {{ a }}"
+    result = variables(tpl)
+    assert [v["name"] for v in result] == ["b", "a"]
+
+
+def test_variables_on_template_class():
+    tpl = Template("Date: {{ date }}\n{% sender.bank_name = 'Vietcombank' %}")
+    result = tpl.variables()
+    assert result == [
+        {"name": "date", "type": "str", "execution": "extract"},
+        {"name": "sender.bank_name", "type": "str", "execution": "static_assign", "value": "Vietcombank"},
+    ]
+
+
+def test_variables_result_is_json_serialisable():
+    import json
+    tpl = "{{ date }} {% bank = 'VCB' %}"
+    assert json.dumps(variables(tpl))  # must not raise


### PR DESCRIPTION
## Summary

- Adds `variables(template_str)` standalone function
- Adds `Template.variables()` method
- Each entry returns `name`, `type`, `execution` (`extract` | `static_assign`), and `value` (static assignments only)
- Result is always `json.dumps()`-safe and in document order

## Test plan

- [ ] `test_variables_extract_only` — extract-only variables
- [ ] `test_variables_static_assign_only` — static assignment variables
- [ ] `test_variables_mixed` — both types in one template
- [ ] `test_variables_document_order` — order matches template order
- [ ] `test_variables_on_template_class` — `Template.variables()` method
- [ ] `test_variables_result_is_json_serialisable` — `json.dumps()` does not raise

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)