### PR TITLE
improvement: rename 'execution' field to 'kind' in variables() output

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Amount: {{ amount:float }}
 
 variables(template)
 # [
-#   {"name": "date",             "type": "str",   "execution": "extract"},
-#   {"name": "amount",           "type": "float", "execution": "extract"},
-#   {"name": "sender.bank_name", "type": "str",   "execution": "static_assign", "value": "Vietcombank"},
+#   {"name": "date",             "type": "str",   "kind": "extract"},
+#   {"name": "amount",           "type": "float", "kind": "extract"},
+#   {"name": "sender.bank_name", "type": "str",   "kind": "static_assign", "value": "Vietcombank"},
 # ]
 ```
 

--- a/docthu/__init__.py
+++ b/docthu/__init__.py
@@ -57,9 +57,9 @@ class Template:
         - ``name``      — dotted variable name
         - ``type``      — coercion type (``"str"``, ``"int"``, ``"float"``,
           ``"date"``, ``"datetime"``)
-        - ``execution`` — ``"extract"`` for ``{{ var }}`` tokens or
+        - ``kind``  — ``"extract"`` for ``{{ var }}`` tokens or
           ``"static_assign"`` for ``{% var = 'value' %}`` tokens
-        - ``value``     — present only when ``execution == "static_assign"``
+        - ``value`` — present only when ``kind == "static_assign"``
 
         Items are returned in template (document) order.
         """
@@ -81,9 +81,9 @@ def _variables(tokens) -> list[dict]:
     result = []
     for token in tokens:
         if isinstance(token, VariableToken):
-            result.append({"name": token.name, "type": token.type, "execution": "extract"})
+            result.append({"name": token.name, "type": token.type, "kind": "extract"})
         elif isinstance(token, AssignmentToken):
-            result.append({"name": token.name, "type": "str", "execution": "static_assign", "value": token.value})
+            result.append({"name": token.name, "type": "str", "kind": "static_assign", "value": token.value})
     return result
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -236,8 +236,8 @@ def test_variables_extract_only():
     tpl = "Date: {{ date }} Amount: {{ amount:float }}"
     result = variables(tpl)
     assert result == [
-        {"name": "date", "type": "str", "execution": "extract"},
-        {"name": "amount", "type": "float", "execution": "extract"},
+        {"name": "date", "type": "str", "kind": "extract"},
+        {"name": "amount", "type": "float", "kind": "extract"},
     ]
 
 
@@ -245,7 +245,7 @@ def test_variables_static_assign_only():
     tpl = "{% sender.bank_name = 'Vietcombank' %}\nHello"
     result = variables(tpl)
     assert result == [
-        {"name": "sender.bank_name", "type": "str", "execution": "static_assign", "value": "Vietcombank"},
+        {"name": "sender.bank_name", "type": "str", "kind": "static_assign", "value": "Vietcombank"},
     ]
 
 
@@ -253,9 +253,9 @@ def test_variables_mixed():
     tpl = "Date: {{ date }}\n{% sender.bank_name = 'Vietcombank' %}\nAmount: {{ amount:float }}"
     result = variables(tpl)
     assert result == [
-        {"name": "date", "type": "str", "execution": "extract"},
-        {"name": "sender.bank_name", "type": "str", "execution": "static_assign", "value": "Vietcombank"},
-        {"name": "amount", "type": "float", "execution": "extract"},
+        {"name": "date", "type": "str", "kind": "extract"},
+        {"name": "sender.bank_name", "type": "str", "kind": "static_assign", "value": "Vietcombank"},
+        {"name": "amount", "type": "float", "kind": "extract"},
     ]
 
 
@@ -269,8 +269,8 @@ def test_variables_on_template_class():
     tpl = Template("Date: {{ date }}\n{% sender.bank_name = 'Vietcombank' %}")
     result = tpl.variables()
     assert result == [
-        {"name": "date", "type": "str", "execution": "extract"},
-        {"name": "sender.bank_name", "type": "str", "execution": "static_assign", "value": "Vietcombank"},
+        {"name": "date", "type": "str", "kind": "extract"},
+        {"name": "sender.bank_name", "type": "str", "kind": "static_assign", "value": "Vietcombank"},
     ]
 
 


### PR DESCRIPTION
## Summary

- Renames the `execution` field to `kind` in all `variables()` output
- `execution` implied running something; `kind` is the conventional term for distinguishing schema node variants

## Change

```json
// Before
{"name": "date", "type": "str", "execution": "extract"}

// After
{"name": "date", "type": "str", "kind": "extract"}
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)