### PR TITLE
docs: add API reference and llms.txt, trim README duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cd docthu
 uv sync --dev
 ```
 
-## Python API
+## Quick start
 
 ```python
 from docthu import parse, Template, variables
@@ -60,125 +60,15 @@ from docthu import parse, Template, variables
 # One-shot extraction
 result = parse(template_str, message_str)
 
-# Reusable (template compiled once, matched many times)
+# Compile once, match many times (preferred for loops)
 tpl = Template(template_str)
 result = tpl.match(message_str)
 
-# Inspect the variable schema of a template
-schema = variables(template_str)   # standalone, one-shot
-schema = tpl.variables()           # or on a compiled Template
+# Inspect the variable schema without extracting
+schema = variables(template_str)
 ```
 
-### Template syntax
-
-| Syntax | Meaning |
-|---|---|
-| `{{ var }}` | Extract value as string |
-| `{{ var:int }}` | Extract and coerce to `int` |
-| `{{ var:float }}` | Extract and coerce to `float` |
-| `{{ var:date }}` | Extract and coerce to `datetime.date` |
-| `{{ var:datetime }}` | Extract and coerce to `datetime.datetime` |
-| `{{ a.b.c }}` | Nested output: `{"a": {"b": {"c": value}}}` |
-| `{% var = 'literal' %}` | Static assignment — no extraction, direct output |
-
-### Example
-
-Template:
-
-```
-Transaction successful.
-Date: {{ date:date }}
-From: {{ sender.account_number }} ({{ sender.bank }})
-To: {{ receiver.account_number }} - {{ receiver.name }}
-Amount: {{ amount:float }} {{ currency }}
-Note: {{ narration }}
-{% type = 'transfer' %}
-```
-
-Message:
-
-```
-Transaction successful.
-Date: 17/03/2026
-From: 1234567890 (Vietcombank)
-To: 9876543210 - NGUYEN VAN A
-Amount: 5,000,000 VND
-Note: school fees
-```
-
-Result:
-
-```json
-{
-  "date": "2026-03-17",
-  "sender": { "account_number": "1234567890", "bank": "Vietcombank" },
-  "receiver": { "account_number": "9876543210", "name": "NGUYEN VAN A" },
-  "amount": 5000000.0,
-  "currency": "VND",
-  "narration": "school fees",
-  "type": "transfer"
-}
-```
-
-### Type coercion
-
-| Type | Behaviour |
-|---|---|
-| `str` | Identity — returned as-is |
-| `int` | Strips thousand separators (`,` and `.`), converts to int |
-| `float` | Auto-detects locale: `1.327,45` → `1327.45`, `1,327.45` → `1327.45` |
-| `date` | Tries common formats: `dd/mm/yyyy`, `yyyy-mm-dd`, `dd-mm-yyyy`, `dd.mm.yyyy`, etc. |
-| `datetime` | Same date formats plus time component |
-
-### Exceptions
-
-```python
-from docthu import TemplateParseError, MatchError, CoercionError
-
-try:
-    result = parse(template, message)
-except TemplateParseError as e:
-    # Bad template syntax (unknown type, adjacent variables, etc.)
-    ...
-except MatchError as e:
-    # Message doesn't match the template structure
-    ...
-except CoercionError as e:
-    # Extracted value couldn't be coerced to the declared type
-    print(e.var_name, e.raw_value, e.target_type)
-```
-
-### Exporting the variable schema
-
-`variables()` returns the list of variables declared in a template as JSON-serialisable dicts, without running an extraction. Useful for generating UI schemas, validating template coverage, or storing template metadata.
-
-```python
-from docthu import variables, Template
-
-template = """\
-Date: {{ date }}
-Amount: {{ amount:float }}
-{% sender.bank_name = 'Vietcombank' %}
-"""
-
-variables(template)
-# [
-#   {"name": "date",             "type": "str",   "kind": "extract"},
-#   {"name": "amount",           "type": "float", "kind": "extract"},
-#   {"name": "sender.bank_name", "type": "str",   "kind": "static_assign", "value": "Vietcombank"},
-# ]
-```
-
-Each entry contains:
-
-| Field | Values | Description |
-|---|---|---|
-| `name` | dotted path string | Variable name as declared in the template |
-| `type` | `str`, `int`, `float`, `date`, `datetime` | Coercion type |
-| `execution` | `extract` \| `static_assign` | `extract` for `{{ var }}` tokens; `static_assign` for `{% var = 'value' %}` tokens |
-| `value` | string | Present only when `execution == "static_assign"` — the literal assigned value |
-
-Items are returned in document order. The result is always `json.dumps()`-safe.
+For the full API — function signatures, template syntax, type coercion rules, exceptions, and the `variables()` schema — see **[docs/api.md](docs/api.md)**.
 
 ## Use cases
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,214 @@
+# docthu API Reference
+
+## Public symbols
+
+```python
+from docthu import parse, Template, variables
+from docthu import TemplateParseError, MatchError, CoercionError
+```
+
+---
+
+## `parse(template, message, *, flexible=True)`
+
+One-shot extraction. Tokenises `template` and matches it against `message`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `template` | `str` | Template string |
+| `message` | `str` | Message to extract from |
+| `flexible` | `bool` | When `True` (default), whitespace differences between template and message are ignored |
+
+**Returns** `dict` — a (possibly nested) dict of extracted values.
+
+**Raises** `TemplateParseError` if the template syntax is invalid.  
+**Raises** `MatchError` if the message doesn't match the template structure.  
+**Raises** `CoercionError` if a typed variable can't be converted.
+
+For repeated extraction against the same template, prefer `Template` to avoid re-parsing on every call.
+
+---
+
+## `Template(template, *, flexible=True)`
+
+Compiled extraction template. Parse once, match many times.
+
+### Constructor
+
+| Parameter | Type | Description |
+|---|---|---|
+| `template` | `str` | Template string |
+| `flexible` | `bool` | See `parse()` |
+
+**Raises** `TemplateParseError` on invalid template syntax.
+
+### `Template.match(message)`
+
+Extract variables from `message`.
+
+**Returns** `dict`.  
+**Raises** `MatchError`, `CoercionError`.
+
+### `Template.variables()`
+
+Return the variable schema of this template as a list of dicts. Same output as the standalone `variables()` function.
+
+---
+
+## `variables(template)`
+
+Return the variables declared in `template` as a list of JSON-serialisable dicts, without running an extraction. Useful for generating UI schemas or validating template coverage.
+
+**Returns** `list[dict]`, in document order. Each dict contains:
+
+| Field | Values | Description |
+|---|---|---|
+| `name` | dotted path string | Variable name as declared in the template |
+| `type` | `str`, `int`, `float`, `date`, `datetime` | Coercion type |
+| `kind` | `extract` \| `static_assign` | `extract` for `{{ var }}` tokens; `static_assign` for `{% var = 'value' %}` tokens |
+| `value` | string | Present only when `kind == "static_assign"` — the literal value |
+
+```python
+from docthu import variables
+
+template = """\
+Date: {{ date }}
+Amount: {{ amount:float }}
+{% sender.bank_name = 'Vietcombank' %}
+"""
+
+variables(template)
+# [
+#   {"name": "date",             "type": "str",   "kind": "extract"},
+#   {"name": "amount",           "type": "float", "kind": "extract"},
+#   {"name": "sender.bank_name", "type": "str",   "kind": "static_assign", "value": "Vietcombank"},
+# ]
+```
+
+---
+
+## Template syntax
+
+### Variable placeholders
+
+| Syntax | Meaning |
+|---|---|
+| `{{ var }}` | Extract value as string |
+| `{{ var:int }}` | Extract and coerce to `int` |
+| `{{ var:float }}` | Extract and coerce to `float` |
+| `{{ var:date }}` | Extract and coerce to `datetime.date` |
+| `{{ var:datetime }}` | Extract and coerce to `datetime.datetime` |
+| `{{ a.b.c }}` | Nested output: `{"a": {"b": {"c": value}}}` |
+
+### Static assignments
+
+```
+{% var = 'literal' %}
+{% var:int = 42 %}
+{% var:float = 3.14 %}
+```
+
+Hard-code a field without extracting it. Supports single-quoted strings, int literals, float literals, and `true`/`false`. The field appears in the result dict at the declared name (dotted paths work here too).
+
+### Constraints
+
+Two variable placeholders cannot be adjacent — there must be at least one literal character between them. Violating this raises `TemplateParseError`.
+
+---
+
+## Type coercion
+
+| Type | Behaviour |
+|---|---|
+| `str` | Identity — returned as-is |
+| `int` | Strips thousand separators (`,` and `.`), converts to `int` |
+| `float` | Auto-detects locale: `1.327,45` → `1327.45`, `1,327.45` → `1327.45` |
+| `date` | Tries `dd/mm/yyyy`, `yyyy-mm-dd`, `dd-mm-yyyy`, `dd.mm.yyyy`, `mm/dd/yyyy`, `yyyy/mm/dd` |
+| `datetime` | Same date formats plus an optional `HH:MM:SS` or `HH:MM` time component |
+
+Dates and datetimes are returned as `datetime.date` / `datetime.datetime` objects (JSON-serialisable via `str()`).
+
+---
+
+## Exceptions
+
+```python
+from docthu import TemplateParseError, MatchError, CoercionError
+```
+
+| Exception | Raised when |
+|---|---|
+| `TemplateParseError` | Template syntax is invalid: unknown type annotation, adjacent variables, malformed `{% %}` block |
+| `MatchError` | The message doesn't match the template's static structure |
+| `CoercionError` | An extracted value can't be converted to its declared type |
+
+`CoercionError` exposes three attributes:
+
+| Attribute | Description |
+|---|---|
+| `var_name` | Name of the variable that failed coercion |
+| `raw_value` | The extracted string that couldn't be converted |
+| `target_type` | The declared type string (e.g. `"int"`) |
+
+```python
+try:
+    result = parse(template, message)
+except TemplateParseError as e:
+    # Bad template syntax
+    print(e)
+except MatchError as e:
+    # Message doesn't match template
+    print(e)
+except CoercionError as e:
+    print(e.var_name, e.raw_value, e.target_type)
+```
+
+---
+
+## End-to-end example
+
+**Template** (`bank_transfer.txt`):
+
+```
+Transaction successful.
+Date: {{ date:date }}
+From: {{ sender.account_number }} ({{ sender.bank }})
+To: {{ receiver.account_number }} - {{ receiver.name }}
+Amount: {{ amount:float }} {{ currency }}
+Note: {{ narration }}
+{% type = 'transfer' %}
+```
+
+**Message:**
+
+```
+Transaction successful.
+Date: 17/03/2026
+From: 1234567890 (Vietcombank)
+To: 9876543210 - NGUYEN VAN A
+Amount: 5,000,000 VND
+Note: school fees
+```
+
+**Code:**
+
+```python
+from docthu import Template
+
+tpl = Template(open("bank_transfer.txt").read())
+result = tpl.match(open("email_body.txt").read())
+```
+
+**Result:**
+
+```json
+{
+  "date": "2026-03-17",
+  "sender": { "account_number": "1234567890", "bank": "Vietcombank" },
+  "receiver": { "account_number": "9876543210", "name": "NGUYEN VAN A" },
+  "amount": 5000000.0,
+  "currency": "VND",
+  "narration": "school fees",
+  "type": "transfer"
+}
+```

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,173 @@
+# docthu
+
+docthu is a template-based structured data extraction library for Python. Describe the format of a message once using a plain-text or HTML template with embedded variable placeholders, then automatically extract structured data from any message that follows that format.
+
+## Installation
+
+```bash
+uv add git+https://github.com/locnguyenvu/docthu.git
+```
+
+## Quick start
+
+```python
+from docthu import parse, Template, variables
+
+# One-shot extraction
+result = parse(template_str, message_str)
+
+# Compile once, reuse many times (preferred for loops)
+tpl = Template(template_str)
+result = tpl.match(message_str)
+
+# Inspect variable schema without extracting
+schema = variables(template_str)
+schema = tpl.variables()          # equivalent, on a compiled Template
+```
+
+## Public API
+
+### parse(template, message, *, flexible=True) -> dict
+
+Tokenises `template` and matches it against `message` in one call.
+
+- `template` (str): template string
+- `message` (str): message to extract from
+- `flexible` (bool, default True): ignore whitespace differences between template and message
+
+Returns a (possibly nested) dict of extracted values.
+Raises TemplateParseError, MatchError, CoercionError.
+
+### Template(template, *, flexible=True)
+
+Compiled template. Parse once, call .match() many times.
+
+- `Template.match(message) -> dict` — extract from message
+- `Template.variables() -> list[dict]` — return variable schema (same as standalone variables())
+
+### variables(template) -> list[dict]
+
+Return variable schema without extracting. Each item:
+
+```python
+{"name": "amount", "type": "float", "kind": "extract"}
+{"name": "bank",   "type": "str",   "kind": "static_assign", "value": "Vietcombank"}
+```
+
+Fields: name (dotted path), type (str/int/float/date/datetime), kind (extract|static_assign), value (only when kind==static_assign).
+
+### Exceptions
+
+```python
+from docthu import TemplateParseError, MatchError, CoercionError
+
+try:
+    result = parse(template, message)
+except TemplateParseError:
+    # Invalid template: unknown type, adjacent variables, bad {% %} block
+    pass
+except MatchError:
+    # Message doesn't match the template's static structure
+    pass
+except CoercionError as e:
+    # e.var_name, e.raw_value, e.target_type
+    pass
+```
+
+## Template syntax
+
+### Variable placeholders
+
+```
+{{ var }}           # extract as string
+{{ var:int }}       # extract and coerce to int
+{{ var:float }}     # extract and coerce to float
+{{ var:date }}      # extract and coerce to datetime.date
+{{ var:datetime }}  # extract and coerce to datetime.datetime
+{{ a.b.c }}         # nested output: {"a": {"b": {"c": value}}}
+```
+
+### Static assignments (no extraction)
+
+```
+{% var = 'literal string' %}
+{% var:int = 42 %}
+{% var:float = 3.14 %}
+```
+
+Adds a hard-coded field to the result dict. Supports single-quoted strings, int, float, and true/false literals.
+
+### Constraints
+
+- Two `{{ }}` variables cannot be adjacent — at least one literal character must separate them.
+- Type annotations must be one of: str, int, float, date, datetime.
+
+## Type coercion
+
+- str: identity, returned as-is
+- int: strips thousand separators (, and .), converts to int
+- float: auto-detects locale — "1.327,45" → 1327.45, "1,327.45" → 1327.45
+- date: tries dd/mm/yyyy, yyyy-mm-dd, dd-mm-yyyy, dd.mm.yyyy, mm/dd/yyyy, yyyy/mm/dd
+- datetime: same date formats + optional HH:MM:SS or HH:MM time component
+
+date → datetime.date object; datetime → datetime.datetime object.
+
+## End-to-end example
+
+Template file (bank_transfer.txt):
+
+```
+Transaction successful.
+Date: {{ date:date }}
+From: {{ sender.account_number }} ({{ sender.bank }})
+To: {{ receiver.account_number }} - {{ receiver.name }}
+Amount: {{ amount:float }} {{ currency }}
+Note: {{ narration }}
+{% type = 'transfer' %}
+```
+
+Message:
+
+```
+Transaction successful.
+Date: 17/03/2026
+From: 1234567890 (Vietcombank)
+To: 9876543210 - NGUYEN VAN A
+Amount: 5,000,000 VND
+Note: school fees
+```
+
+Code:
+
+```python
+from docthu import Template
+
+tpl = Template(open("bank_transfer.txt").read())
+result = tpl.match(message_body)
+```
+
+Result:
+
+```json
+{
+  "date": "2026-03-17",
+  "sender": {"account_number": "1234567890", "bank": "Vietcombank"},
+  "receiver": {"account_number": "9876543210", "name": "NGUYEN VAN A"},
+  "amount": 5000000.0,
+  "currency": "VND",
+  "narration": "school fees",
+  "type": "transfer"
+}
+```
+
+## Using with HTML email templates
+
+docthu works with both plain-text and HTML templates. For HTML emails, pass the raw HTML (or parsed text content) as the template. The `flexible=True` default handles whitespace differences introduced by HTML rendering.
+
+Typical workflow with the bundled template builder UI:
+
+```bash
+uv run docthu   # opens Streamlit app
+```
+
+Upload a .eml file, select text spans to define variables, download the resulting template, then use it with Template or parse().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docthu"
-version = "0.3.0"
+version = "0.4.0"
 description = "Template-based structured data extraction from emails and text messages"
 requires-python = ">=3.10"
 dependencies = ["streamlit>=1.35"]


### PR DESCRIPTION
Closes #7

## Summary

- **`docs/api.md`** — full API reference: all public symbols (`parse`, `Template`, `variables`), template syntax, type coercion table, exception details, end-to-end example
- **`llms.txt`** — machine-readable file (llms.txt convention) for LLM-powered coding assistants to ingest the interface and generate correct usage code
- **`README.md`** — replaced the duplicated Python API sections with a 6-line quick-start snippet and a link to `docs/api.md`; also fixes a stale `execution` → `kind` field name in the variables schema table
- **`pyproject.toml`** — version bumped to `0.4.0`

## Test plan

- [ ] README renders correctly on GitHub — quick-start is present, link to `docs/api.md` works
- [ ] `docs/api.md` covers every public symbol and matches actual code behaviour
- [ ] `llms.txt` is accessible at repo root
- [ ] No content from `docs/api.md` duplicated in `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)