### PR TITLE
feat: add stop_on_filled for early-exit extraction

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ from docthu import TemplateParseError, MatchError, CoercionError
 
 ---
 
-## `parse(template, message, *, flexible=True)`
+## `parse(template, message, *, flexible=True, stop_on_filled=None)`
 
 One-shot extraction. Tokenises `template` and matches it against `message`.
 
@@ -18,6 +18,7 @@ One-shot extraction. Tokenises `template` and matches it against `message`.
 | `template` | `str` | Template string |
 | `message` | `str` | Message to extract from |
 | `flexible` | `bool` | When `True` (default), whitespace differences between template and message are ignored |
+| `stop_on_filled` | `list[str] \| None` | List of variable names the caller requires. The engine stops matching as soon as all of them can be captured. See [Early exit](#early-exit-stop_on_filled) |
 
 **Returns** `dict` — a (possibly nested) dict of extracted values.
 
@@ -42,9 +43,14 @@ Compiled extraction template. Parse once, match many times.
 
 **Raises** `TemplateParseError` on invalid template syntax.
 
-### `Template.match(message)`
+### `Template.match(message, *, stop_on_filled=None)`
 
 Extract variables from `message`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `message` | `str` | Message to extract from |
+| `stop_on_filled` | `list[str] \| None` | See [Early exit](#early-exit-stop_on_filled) |
 
 **Returns** `dict`.  
 **Raises** `MatchError`, `CoercionError`.
@@ -161,6 +167,32 @@ except MatchError as e:
     print(e)
 except CoercionError as e:
     print(e.var_name, e.raw_value, e.target_type)
+```
+
+---
+
+## Early exit (`stop_on_filled`)
+
+Pass a list of variable names to `stop_on_filled` when you only need a subset of the template's variables. The engine finds the rightmost listed variable in template order, truncates the token list there, and compiles a shorter regex — skipping the rest of the template entirely.
+
+**Semantics:**
+- List order is irrelevant; only template position matters.
+- All names in the list must exist as variables in the template — raises `ValueError` otherwise.
+- All names must be captured after matching — raises `MatchError` otherwise.
+- Variables between the start and the cutoff that are not in the list are also captured (they anchor the regex) and appear in the result.
+
+**Typical use case — bilingual emails:**
+
+Many bank emails repeat the same data in two languages. The full template would cover both sections, but you only need the first:
+
+```python
+from docthu import Template
+
+# Template covers both English and Vietnamese sections
+tpl = Template(open("bank_bilingual.txt").read())
+
+# Stop as soon as amount and date are captured — skip the Vietnamese duplicate
+result = tpl.match(email_body, stop_on_filled=["amount", "date"])
 ```
 
 ---

--- a/docthu/__init__.py
+++ b/docthu/__init__.py
@@ -65,16 +65,22 @@ class Template:
         """
         return _variables(self._tokens)
 
-    def match(self, message: str) -> dict:
+    def match(self, message: str, *, stop_on_filled: list[str] | None = None) -> dict:
         """
         Extract variables from *message* using this template.
 
         Returns a (possibly nested) dict of extracted values.
 
+        *stop_on_filled* — list of variable names the caller requires.  The
+        engine truncates the template at the rightmost listed variable and
+        stops matching there, skipping the rest of the template.  Raises
+        ``ValueError`` if any name is absent from the template; raises
+        :class:`MatchError` if a required variable is not captured.
+
         Raises :class:`MatchError` if the message doesn't fit the template.
         Raises :class:`CoercionError` if a typed variable can't be converted.
         """
-        return extract(self._tokens, message, flexible=self._flexible)
+        return extract(self._tokens, message, flexible=self._flexible, stop_on_filled=stop_on_filled)
 
 
 def _variables(tokens) -> list[dict]:
@@ -96,12 +102,14 @@ def variables(template: str) -> list[dict]:
     return _variables(tokenize(template))
 
 
-def parse(template: str, message: str, *, flexible: bool = True) -> dict:
+def parse(template: str, message: str, *, flexible: bool = True, stop_on_filled: list[str] | None = None) -> dict:
     """
     One-shot convenience wrapper: tokenize *template* and extract from *message*.
 
     For repeated use against the same template, prefer :class:`Template` to
     avoid re-parsing the template on every call.
+
+    *stop_on_filled* — see :meth:`Template.match`.
     """
     tokens = tokenize(template)
-    return extract(tokens, message, flexible=flexible)
+    return extract(tokens, message, flexible=flexible, stop_on_filled=stop_on_filled)

--- a/docthu/matcher.py
+++ b/docthu/matcher.py
@@ -115,13 +115,43 @@ def extract(
     message: str,
     *,
     flexible: bool = True,
+    stop_on_filled: list[str] | None = None,
 ) -> dict:
     """
     Match *message* against the compiled token pattern and return a nested dict.
 
     Raises MatchError if the message doesn't conform to the template structure.
     Raises CoercionError if a typed variable cannot be converted.
+
+    *stop_on_filled* — when given, the engine truncates the token list at the
+    rightmost variable in the set (by template order) and only matches up to
+    that point.  Every name in *stop_on_filled* must exist as a variable in the
+    template; raises ValueError otherwise.  After matching, raises MatchError if
+    any declared variable is absent from the result.
     """
+    if stop_on_filled:
+        req_names = set(stop_on_filled)
+        template_var_names = {t.name for t in tokens if isinstance(t, VariableToken)}
+        missing = req_names - template_var_names
+        if missing:
+            raise ValueError(
+                f"stop_on_filled variable(s) {sorted(missing)!r} not found in template"
+            )
+        last_idx = max(
+            i for i, t in enumerate(tokens)
+            if isinstance(t, VariableToken) and t.name in req_names
+        )
+        # Include the next LiteralToken after the cutoff (if any) so the last
+        # required variable gets a non-greedy quantifier instead of consuming
+        # the rest of the message.
+        anchor = next(
+            (t for t in tokens[last_idx + 1:] if isinstance(t, LiteralToken)),
+            None,
+        )
+        tokens = tokens[:last_idx + 1]
+        if anchor is not None:
+            tokens = [*tokens, anchor]
+
     pattern = compile_tokens(tokens, flexible=flexible)
 
     # Normalise message whitespace in flexible mode before matching
@@ -153,5 +183,17 @@ def extract(
         if isinstance(token, AssignmentToken):
             coerced = coerce(token.name, token.value, token.type)
             _set_nested(result, token.name, coerced)
+
+    # Guarantee all stop_on_filled variables are present in the result
+    if stop_on_filled:
+        for name in stop_on_filled:
+            node: Any = result
+            try:
+                for k in name.split("."):
+                    node = node[k]
+            except KeyError:
+                raise MatchError(
+                    f"Required variable '{name}' was not captured from the message."
+                )
 
     return result

--- a/llms.txt
+++ b/llms.txt
@@ -27,13 +27,14 @@ schema = tpl.variables()          # equivalent, on a compiled Template
 
 ## Public API
 
-### parse(template, message, *, flexible=True) -> dict
+### parse(template, message, *, flexible=True, stop_on_filled=None) -> dict
 
 Tokenises `template` and matches it against `message` in one call.
 
 - `template` (str): template string
 - `message` (str): message to extract from
 - `flexible` (bool, default True): ignore whitespace differences between template and message
+- `stop_on_filled` (list[str] | None, default None): stop matching as soon as all listed variables are captured; see Early exit section below
 
 Returns a (possibly nested) dict of extracted values.
 Raises TemplateParseError, MatchError, CoercionError.
@@ -42,7 +43,7 @@ Raises TemplateParseError, MatchError, CoercionError.
 
 Compiled template. Parse once, call .match() many times.
 
-- `Template.match(message) -> dict` — extract from message
+- `Template.match(message, *, stop_on_filled=None) -> dict` — extract from message; see Early exit section
 - `Template.variables() -> list[dict]` — return variable schema (same as standalone variables())
 
 ### variables(template) -> list[dict]
@@ -158,6 +159,19 @@ Result:
   "narration": "school fees",
   "type": "transfer"
 }
+```
+
+## Early exit (stop_on_filled)
+
+Pass `stop_on_filled` to stop matching as soon as a declared set of variables is captured. The engine truncates the template at the rightmost listed variable (by template order) and compiles a shorter regex.
+
+- List order does not matter — engine cuts at the rightmost by template position.
+- All listed names must exist in the template (raises ValueError otherwise).
+- Useful for bilingual emails where the same data appears twice — declare only the variables you need from the first section.
+
+```python
+# Only capture amount and date; skip the Vietnamese duplicate section
+result = tpl.match(email_body, stop_on_filled=["amount", "date"])
 ```
 
 ## Using with HTML email templates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docthu"
-version = "0.4.0"
+version = "0.5.0"
 description = "Template-based structured data extraction from emails and text messages"
 requires-python = ">=3.10"
 dependencies = ["streamlit>=1.35"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -353,3 +353,57 @@ def test_invalid_block_raises():
 def test_block_missing_equals_raises():
     with pytest.raises(TemplateParseError, match="Invalid assignment syntax"):
         parse("{% no_equals 'value' %}\nHello", "Hello")
+
+
+# ---------------------------------------------------------------------------
+# 16. stop_on_filled — early-exit extraction
+# ---------------------------------------------------------------------------
+
+def test_stop_on_filled_basic():
+    """Stops after capturing the declared variables; rest of template is skipped."""
+    template = "A: {{ a }} B: {{ b }} C: {{ c }} D: {{ d }}"
+    # Message intentionally breaks after field b — full template would fail
+    message = "A: alpha B: beta C: ---GARBAGE---"
+    result = parse(template, message, stop_on_filled=["a", "b"])
+    assert result["a"] == "alpha"
+    assert result["b"] == "beta"
+    assert "c" not in result
+    assert "d" not in result
+
+
+def test_stop_on_filled_order_independent():
+    """List order doesn't matter — engine always cuts at the rightmost by template position."""
+    template = "A: {{ a }} B: {{ b }} C: {{ c }}"
+    message = "A: alpha B: beta C: ---GARBAGE---"
+    r1 = parse(template, message, stop_on_filled=["b", "a"])
+    r2 = parse(template, message, stop_on_filled=["a", "b"])
+    assert r1 == r2
+    assert r1["a"] == "alpha"
+    assert r1["b"] == "beta"
+
+
+def test_stop_on_filled_all_variables():
+    """Declaring all variables is equivalent to a full extraction."""
+    template = "Name: {{ name }} Code: {{ code }}"
+    message = "Name: Alice Code: 001"
+    result_full = parse(template, message)
+    result_sof = parse(template, message, stop_on_filled=["name", "code"])
+    assert result_full == result_sof
+
+
+def test_stop_on_filled_unknown_variable_raises():
+    """Names not in the template raise ValueError at call time."""
+    template = "A: {{ a }} B: {{ b }}"
+    message = "A: x B: y"
+    with pytest.raises(ValueError, match="not found in template"):
+        parse(template, message, stop_on_filled=["nonexistent"])
+
+
+def test_stop_on_filled_template_class():
+    """Template.match() supports stop_on_filled the same way."""
+    tpl = Template("A: {{ a }} B: {{ b }} C: {{ c }}")
+    message = "A: alpha B: beta C: ---GARBAGE---"
+    result = tpl.match(message, stop_on_filled=["a", "b"])
+    assert result["a"] == "alpha"
+    assert result["b"] == "beta"
+    assert "c" not in result


### PR DESCRIPTION
Closes #10

## Summary

- `parse()` and `Template.match()` accept a new `stop_on_filled=["var1", "var2"]` parameter
- Engine finds the rightmost listed variable in template order, appends the next literal as an anchor (keeps quantifier non-greedy), and compiles a shorter regex — rest of the template is skipped
- **Template-time validation**: raises `ValueError` if any name is absent from the template
- **Match-time guarantee**: raises `MatchError` if a declared variable wasn't captured
- Version bumped to `0.5.0`
- `docs/api.md` and `llms.txt` updated

## Key design decision

List order is irrelevant — the engine always cuts at the **rightmost variable by template position**, which is the minimum depth needed to guarantee all declared variables are captured.

## Test plan

- [ ] `test_stop_on_filled_basic` — stops early, rest of template not needed
- [ ] `test_stop_on_filled_order_independent` — `["b","a"]` == `["a","b"]`
- [ ] `test_stop_on_filled_all_variables` — declaring all vars == full extraction
- [ ] `test_stop_on_filled_unknown_variable_raises` — ValueError on bad name
- [ ] `test_stop_on_filled_template_class` — works via `Template.match()`
- [ ] All 35 existing tests still pass

```
uv run pytest tests/ -v   # 40 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)