### PR TITLE
feat: dynamic list extraction with {% list: name %}...{% end %} blocks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,10 +69,11 @@ Return the variables declared in `template` as a list of JSON-serialisable dicts
 
 | Field | Values | Description |
 |---|---|---|
-| `name` | dotted path string | Variable name as declared in the template |
-| `type` | `str`, `int`, `float`, `date`, `datetime` | Coercion type |
-| `kind` | `extract` \| `static_assign` | `extract` for `{{ var }}` tokens; `static_assign` for `{% var = 'value' %}` tokens |
+| `name` | dotted path string | Variable name (or list block name) as declared in the template |
+| `type` | `str`, `int`, `float`, `date`, `datetime`, `list` | Coercion type (`list` for `{% list: … %}` blocks) |
+| `kind` | `extract` \| `static_assign` \| `list` | `extract` for `{{ var }}`; `static_assign` for `{% var = 'value' %}`; `list` for `{% list: name %}` blocks |
 | `value` | string | Present only when `kind == "static_assign"` — the literal value |
+| `fields` | list of dicts | Present only when `kind == "list"` — field descriptors for items in the list (each has `name`, `type`, `kind`) |
 
 ```python
 from docthu import variables
@@ -116,9 +117,83 @@ variables(template)
 
 Hard-code a field without extracting it. Supports single-quoted strings, int literals, float literals, and `true`/`false`. The field appears in the result dict at the declared name (dotted paths work here too).
 
+### List blocks (dynamic repeated content)
+
+Use `{% list: name %}` … `{% end %}` to extract a variable-length list of structured items — for example, the line items in a shopping order email.
+
+```
+{% list: item %}
+- {{ item.name }} x{{ item.quantity:int }} - ${{ item.price:float }}
+{% end %}
+```
+
+- `item` is the collection name: it becomes a key in the result dict whose value is a `list` of dicts.
+- Variable placeholders inside the block must be prefixed with the collection name (e.g. `item.name`). All standard coercion types are supported.
+- Each item dict contains only the field names relative to the prefix (e.g. `{"name": ..., "quantity": ..., "price": ...}`).
+- Dotted field names are supported: `{{ item.address.city }}` produces `{"address": {"city": ...}}` in each item dict.
+- If no items are found, the collection is set to `[]` (empty list).
+- Nested list blocks raise `TemplateParseError`.
+- `{% list: name %}` and `{% end %}` must each be on their own line; the surrounding blank lines are absorbed automatically.
+
+**Full example:**
+
+Template:
+```
+Order #{{ order_number }}
+
+Items:
+{% list: item %}
+- {{ item.name }} x{{ item.quantity:int }} - ${{ item.price:float }}
+{% end %}
+Subtotal: ${{ subtotal:float }}
+Total: ${{ total:float }}
+```
+
+Message:
+```
+Order #ORD-12345
+
+Items:
+- Widget A x2 - $9.99
+- Widget B x1 - $24.99
+
+Subtotal: $19.98
+Total: $21.98
+```
+
+Result:
+```json
+{
+  "order_number": "ORD-12345",
+  "item": [
+    {"name": "Widget A", "quantity": 2, "price": 9.99},
+    {"name": "Widget B", "quantity": 1, "price": 24.99}
+  ],
+  "subtotal": 19.98,
+  "total": 21.98
+}
+```
+
+**`variables()` schema for list blocks:**
+
+```python
+{
+    "name": "item",
+    "type": "list",
+    "kind": "list",
+    "fields": [
+        {"name": "name",     "type": "str",   "kind": "extract"},
+        {"name": "quantity", "type": "int",   "kind": "extract"},
+        {"name": "price",    "type": "float", "kind": "extract"},
+    ]
+}
+```
+
 ### Constraints
 
-Two variable placeholders cannot be adjacent — there must be at least one literal character between them. Violating this raises `TemplateParseError`.
+- Two variable placeholders cannot be adjacent — there must be at least one literal character between them. Violating this raises `TemplateParseError`.
+- Nested `{% list: … %}` blocks are not supported.
+- `stop_on_filled` cannot reference loop-body variables — raises `ValueError`.
 
 ---
 

--- a/docthu/__init__.py
+++ b/docthu/__init__.py
@@ -16,7 +16,14 @@ from __future__ import annotations
 
 from .coercion import CoercionError
 from .matcher import MatchError, extract
-from .tokenizer import AssignmentToken, TemplateParseError, VariableToken, tokenize
+from .tokenizer import (
+    AssignmentToken,
+    EndToken,
+    ListToken,
+    TemplateParseError,
+    VariableToken,
+    tokenize,
+)
 
 __all__ = [
     "Template",
@@ -38,7 +45,7 @@ class Template:
     ----------
     template:
         Template string using ``{{ var }}`` / ``{{ var:type }}`` /
-        ``{% var = 'value' %}`` syntax.
+        ``{% var = 'value' %}`` / ``{% list: name %}`` … ``{% end %}`` syntax.
     flexible:
         When *True* (default), whitespace differences between the template
         and the message are ignored.
@@ -54,12 +61,15 @@ class Template:
 
         Each dict has the keys:
 
-        - ``name``      — dotted variable name
+        - ``name``      — dotted variable name (or list block name)
         - ``type``      — coercion type (``"str"``, ``"int"``, ``"float"``,
-          ``"date"``, ``"datetime"``)
-        - ``kind``  — ``"extract"`` for ``{{ var }}`` tokens or
-          ``"static_assign"`` for ``{% var = 'value' %}`` tokens
+          ``"date"``, ``"datetime"``, or ``"list"`` for list blocks)
+        - ``kind``  — ``"extract"`` for ``{{ var }}`` tokens,
+          ``"static_assign"`` for ``{% var = 'value' %}`` tokens, or
+          ``"list"`` for ``{% list: name %}`` blocks
         - ``value`` — present only when ``kind == "static_assign"``
+        - ``fields`` — present only when ``kind == "list"``: list of field
+          descriptors (each with ``name``, ``type``, ``kind``)
 
         Items are returned in template (document) order.
         """
@@ -74,8 +84,9 @@ class Template:
         *stop_on_filled* — list of variable names the caller requires.  The
         engine truncates the template at the rightmost listed variable and
         stops matching there, skipping the rest of the template.  Raises
-        ``ValueError`` if any name is absent from the template; raises
-        :class:`MatchError` if a required variable is not captured.
+        ``ValueError`` if any name is absent from the template or refers to a
+        loop-body variable; raises :class:`MatchError` if a required variable
+        is not captured.
 
         Raises :class:`MatchError` if the message doesn't fit the template.
         Raises :class:`CoercionError` if a typed variable can't be converted.
@@ -85,11 +96,30 @@ class Template:
 
 def _variables(tokens) -> list[dict]:
     result = []
+    current_list: dict | None = None
     for token in tokens:
-        if isinstance(token, VariableToken):
-            result.append({"name": token.name, "type": token.type, "kind": "extract"})
+        if isinstance(token, ListToken):
+            current_list = {
+                "name": token.name,
+                "type": "list",
+                "kind": "list",
+                "fields": [],
+            }
+            result.append(current_list)
+        elif isinstance(token, EndToken):
+            current_list = None
+        elif isinstance(token, VariableToken):
+            if current_list is not None:
+                field_name = token.name[len(current_list["name"]) + 1:]
+                current_list["fields"].append(
+                    {"name": field_name, "type": token.type, "kind": "extract"}
+                )
+            else:
+                result.append({"name": token.name, "type": token.type, "kind": "extract"})
         elif isinstance(token, AssignmentToken):
-            result.append({"name": token.name, "type": token.type, "kind": "static_assign", "value": token.value})
+            result.append(
+                {"name": token.name, "type": token.type, "kind": "static_assign", "value": token.value}
+            )
     return result
 
 

--- a/docthu/matcher.py
+++ b/docthu/matcher.py
@@ -6,10 +6,11 @@ and build the nested output dict.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from typing import Any
 
 from .coercion import CoercionError, coerce  # noqa: F401 — re-exported for convenience
-from .tokenizer import AssignmentToken, LiteralToken, VariableToken
+from .tokenizer import AssignmentToken, EndToken, LiteralToken, ListToken, VariableToken
 
 # Public so __init__.py can import it
 __all__ = ["MatchError", "compile_tokens", "extract"]
@@ -52,55 +53,269 @@ def _var_group_name(dotted_name: str) -> str:
     return dotted_name.replace(".", "__")
 
 
-def compile_tokens(
-    tokens: list[LiteralToken | VariableToken | AssignmentToken],
-    flexible: bool = True,
-) -> re.Pattern:
-    """
-    Convert a token list to a compiled regex.
+# ---------------------------------------------------------------------------
+# Compiled template structures
+# ---------------------------------------------------------------------------
 
-    Variables become named capture groups; literals become escaped text.
-    AssignmentTokens are ignored (they don't contribute to the pattern).
-    """
-    # Collect only the tokens that produce regex output (literals + variables)
-    active = [t for t in tokens if not isinstance(t, AssignmentToken)]
 
-    # Index of the first and last LiteralToken in active
+@dataclass
+class LoopSpec:
+    name: str                        # collection key and object prefix, e.g. "item"
+    blob_group: str                  # regex group name in the main pattern, e.g. "__list_item"
+    body_pattern: re.Pattern         # sub-regex applied per-item via finditer
+    body_var_tokens: list            # VariableToken list for variables inside the loop body
+
+
+@dataclass
+class CompiledTemplate:
+    pattern: re.Pattern
+    loop_specs: list                 # list[LoopSpec]
+    outer_var_tokens: dict           # group_name → VariableToken (non-loop vars)
+    assignment_tokens: list          # list[AssignmentToken]
+
+
+# ---------------------------------------------------------------------------
+# Segmentation helpers
+# ---------------------------------------------------------------------------
+
+
+def _split_loop_blocks(tokens):
+    """
+    Partition the flat token list into segments:
+      ('outer', [tokens])
+      ('loop',  ListToken, [body_tokens])
+    """
+    segments = []
+    outer_buf = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if isinstance(token, ListToken):
+            if outer_buf:
+                segments.append(("outer", outer_buf))
+                outer_buf = []
+            j = i + 1
+            body = []
+            while j < len(tokens) and not isinstance(tokens[j], EndToken):
+                body.append(tokens[j])
+                j += 1
+            segments.append(("loop", token, body))
+            i = j + 1  # skip EndToken
+        elif isinstance(token, EndToken):
+            i += 1  # already consumed by ListToken handler; skip stray EndToken
+        else:
+            outer_buf.append(token)
+            i += 1
+    if outer_buf:
+        segments.append(("outer", outer_buf))
+    return segments
+
+
+def _outer_tokens(tokens):
+    """Return only the tokens that live outside any list block."""
+    result = []
+    in_loop = False
+    for t in tokens:
+        if isinstance(t, ListToken):
+            in_loop = True
+        elif isinstance(t, EndToken):
+            in_loop = False
+        elif not in_loop:
+            result.append(t)
+    return result
+
+
+def _loop_var_names(tokens):
+    """Return the set of VariableToken names that live inside list blocks."""
+    names = set()
+    in_loop = False
+    for t in tokens:
+        if isinstance(t, ListToken):
+            in_loop = True
+        elif isinstance(t, EndToken):
+            in_loop = False
+        elif in_loop and isinstance(t, VariableToken):
+            names.add(t.name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Body sub-pattern compilation
+# ---------------------------------------------------------------------------
+
+
+def _compile_body_tokens(body_tokens, list_name: str, flexible: bool) -> re.Pattern:
+    """
+    Compile the loop-body tokens into a sub-regex for use with finditer.
+
+    Variable names like ``item.name`` have their ``item.`` prefix stripped;
+    the group name becomes ``name``.  All variables use non-greedy quantifiers
+    when any literal follows them (even whitespace-only), so finditer can
+    correctly delimit individual items.
+    """
+    prefix = list_name + "."
+    active = [t for t in body_tokens if not isinstance(t, AssignmentToken)]
+
     first_literal_idx = next(
-        (i for i, t in enumerate(active) if isinstance(t, LiteralToken)),
-        -1,
+        (i for i, t in enumerate(active) if isinstance(t, LiteralToken)), -1
     )
     last_literal_idx = max(
-        (i for i, t in enumerate(active) if isinstance(t, LiteralToken)),
-        default=-1,
+        (i for i, t in enumerate(active) if isinstance(t, LiteralToken)), default=-1
     )
 
     parts: list[str] = []
     for i, token in enumerate(active):
         if isinstance(token, LiteralToken):
-            is_head = i == first_literal_idx
-            is_tail = i == last_literal_idx
-            parts.append(_literal_to_pattern(token.text, flexible, is_tail=is_tail, is_head=is_head))
+            # No is_head/is_tail treatment for body literals — the body is a
+            # repeated unit and doesn't need BOM or HTML-tag workarounds.
+            parts.append(_literal_to_pattern(token.text, flexible))
         elif isinstance(token, VariableToken):
-            group = _var_group_name(token.name)
-            # Last active token that is a variable gets greedy match
-            is_last_var = not any(isinstance(t, VariableToken) for t in active[i + 1 :])
-            # Also check if anything follows after this variable
-            has_following_literal = any(
-                isinstance(t, LiteralToken) and t.text.strip() for t in active[i + 1 :]
+            field_name = (
+                token.name[len(prefix):]
+                if token.name.startswith(prefix)
+                else token.name
             )
+            group = _var_group_name(field_name)
+            is_last_var = not any(isinstance(t, VariableToken) for t in active[i + 1:])
+            # For body patterns: ANY following literal (even whitespace-only) is
+            # enough to bound the match, so we use non-greedy +? in that case.
+            has_following_literal = any(isinstance(t, LiteralToken) for t in active[i + 1:])
             if is_last_var and not has_following_literal:
-                quantifier = r"[\s\S]+"  # greedy, consumes rest
+                quantifier = r"[\s\S]+"
             else:
-                quantifier = r"[\s\S]+?"  # non-greedy
-
+                quantifier = r"[\s\S]+?"
             parts.append(f"(?P<{group}>{quantifier})")
 
-    pattern = "".join(parts)
+    pattern_str = "".join(parts)
     try:
-        return re.compile(pattern, re.DOTALL)
+        return re.compile(pattern_str, re.DOTALL)
+    except re.error as exc:
+        raise ValueError(f"Failed to compile loop body regex: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Main compile_tokens
+# ---------------------------------------------------------------------------
+
+
+def compile_tokens(
+    tokens: list,
+    flexible: bool = True,
+) -> CompiledTemplate:
+    """
+    Convert a token list to a :class:`CompiledTemplate`.
+
+    For templates without list blocks the result behaves like the former
+    ``re.Pattern`` return value (accessible via ``.pattern``).
+    """
+    segments = _split_loop_blocks(tokens)
+
+    # Build a flat list of "main-pattern elements" for position-aware compilation
+    # Each element is one of:
+    #   ('literal',  LiteralToken)
+    #   ('variable', VariableToken)
+    #   ('blob',     ListToken, body_tokens)
+    main_elements = []
+    for seg in segments:
+        if seg[0] == "outer":
+            for t in seg[1]:
+                if isinstance(t, LiteralToken):
+                    main_elements.append(("literal", t))
+                elif isinstance(t, VariableToken):
+                    main_elements.append(("variable", t))
+                # AssignmentToken: skip — contributes no regex pattern
+        elif seg[0] == "loop":
+            main_elements.append(("blob", seg[1], seg[2]))
+
+    first_lit_idx = next(
+        (i for i, e in enumerate(main_elements) if e[0] == "literal"), -1
+    )
+    last_lit_idx = max(
+        (i for i, e in enumerate(main_elements) if e[0] == "literal"), default=-1
+    )
+
+    parts: list[str] = []
+    outer_var_tokens: dict = {}
+    loop_specs: list[LoopSpec] = []
+    assignment_tokens: list[AssignmentToken] = [
+        t
+        for seg in segments
+        if seg[0] == "outer"
+        for t in seg[1]
+        if isinstance(t, AssignmentToken)
+    ]
+
+    for i, elem in enumerate(main_elements):
+        kind = elem[0]
+
+        if kind == "literal":
+            is_head = i == first_lit_idx
+            is_tail = i == last_lit_idx
+            parts.append(
+                _literal_to_pattern(elem[1].text, flexible, is_tail=is_tail, is_head=is_head)
+            )
+
+        elif kind == "variable":
+            token = elem[1]
+            group = _var_group_name(token.name)
+            outer_var_tokens[group] = token
+
+            is_last_active = not any(
+                e[0] in ("variable", "blob") for e in main_elements[i + 1:]
+            )
+            has_following_literal = any(
+                e[0] == "literal" and e[1].text.strip()
+                for e in main_elements[i + 1:]
+            )
+            if is_last_active and not has_following_literal:
+                quantifier = r"[\s\S]+"
+            else:
+                quantifier = r"[\s\S]+?"
+            parts.append(f"(?P<{group}>{quantifier})")
+
+        elif kind == "blob":
+            list_token = elem[1]
+            body_tokens = elem[2]
+            blob_group = f"__list_{list_token.name}"
+
+            is_last_active = not any(
+                e[0] in ("variable", "blob") for e in main_elements[i + 1:]
+            )
+            has_following_literal = any(
+                e[0] == "literal" and e[1].text.strip()
+                for e in main_elements[i + 1:]
+            )
+            # Use * (zero-or-more) to allow empty lists
+            if is_last_active and not has_following_literal:
+                quantifier = r"[\s\S]*"
+            else:
+                quantifier = r"[\s\S]*?"
+            parts.append(f"(?P<{blob_group}>{quantifier})")
+
+            body_pattern = _compile_body_tokens(body_tokens, list_token.name, flexible)
+            body_var_tokens = [t for t in body_tokens if isinstance(t, VariableToken)]
+
+            loop_specs.append(
+                LoopSpec(
+                    name=list_token.name,
+                    blob_group=blob_group,
+                    body_pattern=body_pattern,
+                    body_var_tokens=body_var_tokens,
+                )
+            )
+
+    pattern_str = "".join(parts)
+    try:
+        main_pattern = re.compile(pattern_str, re.DOTALL)
     except re.error as exc:
         raise ValueError(f"Failed to compile template regex: {exc}") from exc
+
+    return CompiledTemplate(
+        pattern=main_pattern,
+        loop_specs=loop_specs,
+        outer_var_tokens=outer_var_tokens,
+        assignment_tokens=assignment_tokens,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +336,7 @@ def _set_nested(d: dict, dotted_key: str, value: Any) -> None:
 
 
 def extract(
-    tokens: list[LiteralToken | VariableToken | AssignmentToken],
+    tokens: list,
     message: str,
     *,
     flexible: bool = True,
@@ -135,47 +350,52 @@ def extract(
 
     *stop_on_filled* — when given, the engine truncates the token list at the
     rightmost variable in the set (by template order) and only matches up to
-    that point.  Every name in *stop_on_filled* must exist as a variable in the
-    template; raises ValueError otherwise.  After matching, raises MatchError if
-    any declared variable is absent from the result.
+    that point.  Every name in *stop_on_filled* must exist as a non-loop
+    variable in the template; raises ValueError otherwise.  After matching,
+    raises MatchError if any declared variable is absent from the result.
+    Loop-body variables cannot be used in *stop_on_filled*.
     """
     if stop_on_filled:
         req_names = set(stop_on_filled)
-        template_var_names = {t.name for t in tokens if isinstance(t, VariableToken)}
-        template_assign_names = {t.name for t in tokens if isinstance(t, AssignmentToken)}
+
+        loop_vars = _loop_var_names(tokens)
+        loop_stop = req_names & loop_vars
+        if loop_stop:
+            raise ValueError(
+                f"stop_on_filled cannot reference loop-body variables: {sorted(loop_stop)!r}"
+            )
+
+        outer = _outer_tokens(tokens)
+        template_var_names = {t.name for t in outer if isinstance(t, VariableToken)}
+        template_assign_names = {t.name for t in outer if isinstance(t, AssignmentToken)}
         missing = req_names - template_var_names - template_assign_names
         if missing:
             raise ValueError(
                 f"stop_on_filled variable(s) {sorted(missing)!r} not found in template"
             )
-        # Assignment tokens are always filled; only extract variables determine cutoff
+
         extract_req_names = req_names - template_assign_names
         if extract_req_names:
             last_idx = max(
-                i for i, t in enumerate(tokens)
+                i for i, t in enumerate(outer)
                 if isinstance(t, VariableToken) and t.name in extract_req_names
             )
-            # Include a short anchor after the cutoff so the last required variable
-            # gets a non-greedy quantifier instead of consuming the rest of the
-            # message.  Use only text up to the first newline so we don't require
-            # template-specific varying content (dates, amounts, …) that follows
-            # the stop point to be identical in every message.
             anchor = next(
-                (t for t in tokens[last_idx + 1:] if isinstance(t, LiteralToken)),
+                (t for t in outer[last_idx + 1:] if isinstance(t, LiteralToken)),
                 None,
             )
-            tokens = tokens[:last_idx + 1]
+            tokens = outer[:last_idx + 1]
             if anchor is not None:
-                # Skip leading whitespace so an anchor like "\n\t</td>\n" doesn't
-                # reduce to just "\n" (which is useless as a bounding constraint).
                 lead_len = len(anchor.text) - len(anchor.text.lstrip())
                 newline_pos = anchor.text.find("\n", lead_len)
                 anchor_text = (
                     anchor.text[: newline_pos + 1] if newline_pos >= 0 else anchor.text
                 )
                 tokens = [*tokens, LiteralToken(anchor_text)]
+        else:
+            tokens = outer
 
-    pattern = compile_tokens(tokens, flexible=flexible)
+    compiled = compile_tokens(tokens, flexible=flexible)
 
     # Normalise message whitespace in flexible mode before matching
     msg = message.strip()
@@ -183,7 +403,7 @@ def extract(
         msg = _WS_RUN.sub(" ", msg)
         msg = msg + " "  # ensure trailing \s+ in the pattern can always match
 
-    m = pattern.search(msg)
+    m = compiled.pattern.search(msg)
     if m is None:
         raise MatchError(
             "Message does not match the template. "
@@ -192,20 +412,40 @@ def extract(
 
     result: dict = {}
 
-    # Process captured variables
-    var_tokens = {
-        _var_group_name(t.name): t for t in tokens if isinstance(t, VariableToken)
-    }
+    # Process outer (non-loop) captured variables
     for group_name, raw_value in m.groupdict().items():
-        token = var_tokens[group_name]
+        if group_name.startswith("__list_"):
+            continue  # handled in phase 2 below
+        token = compiled.outer_var_tokens[group_name]
         value = coerce(token.name, raw_value.strip(), token.type)
         _set_nested(result, token.name, value)
 
     # Process static assignments
-    for token in tokens:
-        if isinstance(token, AssignmentToken):
-            coerced = coerce(token.name, token.value, token.type)
-            _set_nested(result, token.name, coerced)
+    for token in compiled.assignment_tokens:
+        coerced = coerce(token.name, token.value, token.type)
+        _set_nested(result, token.name, coerced)
+
+    # Phase 2: apply the body sub-pattern to each loop blob
+    prefix_len_cache: dict[str, int] = {}
+    for loop_spec in compiled.loop_specs:
+        blob = m.group(loop_spec.blob_group) or ""
+        prefix = loop_spec.name + "."
+        prefix_len = len(prefix)
+        items = []
+        for item_match in loop_spec.body_pattern.finditer(blob):
+            item_dict: dict = {}
+            for var_token in loop_spec.body_var_tokens:
+                field_name = (
+                    var_token.name[prefix_len:]
+                    if var_token.name.startswith(prefix)
+                    else var_token.name
+                )
+                group = _var_group_name(field_name)
+                raw = item_match.group(group)
+                coerced = coerce(var_token.name, raw.strip(), var_token.type)
+                _set_nested(item_dict, field_name, coerced)
+            items.append(item_dict)
+        result[loop_spec.name] = items
 
     # Guarantee all stop_on_filled variables are present in the result
     if stop_on_filled:

--- a/docthu/tokenizer.py
+++ b/docthu/tokenizer.py
@@ -5,6 +5,8 @@ Token types:
   LiteralToken    — static text fragment
   VariableToken   — {{ name }} or {{ name:type }}
   AssignmentToken — {% name = 'value' %} or {% name:type = value %}
+  ListToken       — {% list: name %} opens a repeated-item block
+  EndToken        — {% end %} closes a list block
 """
 
 from __future__ import annotations
@@ -22,12 +24,18 @@ _RE_ASSIGN = re.compile(
     r"(?:'([^']*)'|(-?\d+\.\d+)|(-?\d+)|(true|false))"
     r"\s*%\}"
 )
+# Matches {% list: name %}
+_RE_LIST = re.compile(r"\{%\s*list\s*:\s*(\w+)\s*%\}")
+# Matches {% end %}
+_RE_END = re.compile(r"\{%\s*end\s*%\}")
 # Matches {{ name }} or {{ name:type }}
 _RE_VAR = re.compile(r"\{{\s*([\w.]+)(?::(\w+))?\s*\}\}")
-# Combined scanner — assignment first so it takes priority
+# Combined scanner — list/end first, then assignment, then variable
 _RE_TOKEN = re.compile(
-    r"(\{%\s*[\w.]+(?::\w+)?\s*=\s*(?:'[^']*'|-?\d+\.\d+|-?\d+|true|false)\s*%\})"
-    r"|(\{{\s*[\w.]+(?::\w+)?\s*\}\})"
+    r"(\{%\s*list\s*:\s*\w+\s*%\})"   # group 1: list block
+    r"|(\{%\s*end\s*%\})"              # group 2: end block
+    r"|(\{%\s*[\w.]+(?::\w+)?\s*=\s*(?:'[^']*'|-?\d+\.\d+|-?\d+|true|false)\s*%\})"  # group 3: assignment
+    r"|(\{{\s*[\w.]+(?::\w+)?\s*\}\})"  # group 4: variable
 )
 # Detects any {% ... %} block (used to catch invalid/unsupported syntax)
 _RE_BLOCK_ATTEMPT = re.compile(r"\{%.*?%\}")
@@ -51,19 +59,30 @@ class AssignmentToken:
     type: str = field(default="str")  # coercion type
 
 
+@dataclass
+class ListToken:
+    name: str  # "item" in {% list: item %} — collection key and object prefix
+
+
+@dataclass
+class EndToken:
+    pass
+
+
 class TemplateParseError(Exception):
     pass
 
 
-def tokenize(template: str) -> list[LiteralToken | VariableToken | AssignmentToken]:
+def tokenize(template: str) -> list[LiteralToken | VariableToken | AssignmentToken | ListToken | EndToken]:
     """
     Parse *template* into an ordered list of tokens.
 
     Assignment blocks that occupy an entire line (possibly with surrounding
     whitespace) are consumed together with their newline so they don't leave
-    a blank-line artifact in the adjacent LiteralTokens.
+    a blank-line artifact in the adjacent LiteralTokens.  The same treatment
+    applies to ``{% list: name %}`` and ``{% end %}`` blocks.
     """
-    tokens: list[LiteralToken | VariableToken | AssignmentToken] = []
+    tokens: list[LiteralToken | VariableToken | AssignmentToken | ListToken | EndToken] = []
     pos = 0
     length = len(template)
 
@@ -80,8 +99,41 @@ def tokenize(template: str) -> list[LiteralToken | VariableToken | AssignmentTok
         before = template[pos : m.start()]
 
         if m.group(1):
-            # AssignmentToken — strip its line from the surrounding literals
-            am = _RE_ASSIGN.fullmatch(m.group(1).strip())
+            # ListToken — absorb its line the same way as AssignmentToken
+            lm = _RE_LIST.fullmatch(m.group(1).strip())
+            before_stripped, after_stripped = _absorb_assignment_line(
+                template, pos, m.start(), m.end()
+            )
+            if before_stripped is not None:
+                if before_stripped:
+                    tokens.append(LiteralToken(before_stripped))
+                tokens.append(ListToken(name=lm.group(1)))
+                pos = m.end() + after_stripped
+                continue
+
+            if before:
+                tokens.append(LiteralToken(before))
+            tokens.append(ListToken(name=lm.group(1)))
+
+        elif m.group(2):
+            # EndToken — absorb its line
+            before_stripped, after_stripped = _absorb_assignment_line(
+                template, pos, m.start(), m.end()
+            )
+            if before_stripped is not None:
+                if before_stripped:
+                    tokens.append(LiteralToken(before_stripped))
+                tokens.append(EndToken())
+                pos = m.end() + after_stripped
+                continue
+
+            if before:
+                tokens.append(LiteralToken(before))
+            tokens.append(EndToken())
+
+        elif m.group(3):
+            # AssignmentToken
+            am = _RE_ASSIGN.fullmatch(m.group(3).strip())
             name = am.group(1)
             explicit_type = am.group(2)   # type annotation, may be None
             str_val = am.group(3)         # single-quoted string
@@ -124,9 +176,9 @@ def tokenize(template: str) -> list[LiteralToken | VariableToken | AssignmentTok
                 tokens.append(LiteralToken(before))
             tokens.append(AssignmentToken(name=name, value=value, type=type_))
 
-        elif m.group(2):
+        elif m.group(4):
             # VariableToken
-            vm = _RE_VAR.fullmatch(m.group(2).strip())
+            vm = _RE_VAR.fullmatch(m.group(4).strip())
             name = vm.group(1)
             type_ = vm.group(2) or "str"
             if type_ not in VALID_TYPES:
@@ -140,14 +192,36 @@ def tokenize(template: str) -> list[LiteralToken | VariableToken | AssignmentTok
 
         pos = m.end()
 
-    # Detect {% ... %} blocks that didn't match the assignment pattern
+    # Detect {% ... %} blocks that didn't match any known pattern
     for bm in _RE_BLOCK_ATTEMPT.finditer(template):
         block = bm.group(0)
-        if not _RE_ASSIGN.fullmatch(block.strip()):
+        if not (
+            _RE_ASSIGN.fullmatch(block.strip())
+            or _RE_LIST.fullmatch(block.strip())
+            or _RE_END.fullmatch(block.strip())
+        ):
             raise TemplateParseError(
-                f"Invalid assignment syntax: {block!r}. "
-                "Expected: {{% name = 'value' %}} or {{% name:type = value %}}"
+                f"Invalid block syntax: {block!r}. "
+                "Expected: {{% name = 'value' %}}, {{% list: name %}}, or {{% end %}}"
             )
+
+    # Validate list/end pairing
+    depth = 0
+    for token in tokens:
+        if isinstance(token, ListToken):
+            if depth > 0:
+                raise TemplateParseError(
+                    "Nested {% list: ... %} blocks are not supported"
+                )
+            depth += 1
+        elif isinstance(token, EndToken):
+            if depth == 0:
+                raise TemplateParseError(
+                    "{% end %} without a matching {% list: ... %}"
+                )
+            depth -= 1
+    if depth > 0:
+        raise TemplateParseError("Unclosed {% list: ... %} block (missing {% end %})")
 
     # Validate: no two VariableTokens are adjacent (no literal between them)
     for i in range(len(tokens) - 1):

--- a/examples/shopee/README.md
+++ b/examples/shopee/README.md
@@ -1,0 +1,148 @@
+# Examples
+
+## shopee/
+
+Shopee order delivery notification emails — a real-world extraction scenario.
+
+### Files
+
+| File | Description |
+|---|---|
+| `template.html` | Annotated template with `{{ variable }}` placeholders |
+| `test1.html` | Single order, two items, no coupon |
+| `test2.html` | Single order, one item, Shopee + Shop coupons applied |
+| `test3.html` | Single order, one item, Shopee coupon applied |
+
+The test files are sanitised copies of real Shopee delivery emails. They represent three common checkout scenarios and can be used to verify that the template correctly extracts all fields across varying order structures.
+
+### Variables extracted
+
+| Variable | Type | Description |
+|---|---|---|
+| `order_id` | str | Order code (e.g. `#2401ABCD123456`) |
+| `order_date` | datetime | Date and time the order was placed |
+| `seller` | str | Shop name |
+| `item.number` | str | Line item index |
+| `item.name` | str | Product name |
+| `item.variant` | str | Selected variant |
+| `item.quantity` | int | Quantity ordered |
+| `item.price` | float | Unit price (VND) |
+| `total` | float | Final amount paid (VND) |
+
+### Running the extraction
+
+```python
+from pathlib import Path
+from docthu import Template
+
+template_str = Path("shopee/template.html").read_text()
+tpl = Template(template_str)
+
+for test_file in ["shopee/test1.html", "shopee/test2.html", "shopee/test3.html"]:
+    message = Path(test_file).read_text()
+    result = tpl.match(message)
+    print(f"--- {test_file} ---")
+    print(result)
+```
+
+Run from the `examples/` directory:
+
+```bash
+cd examples
+python run.py
+```
+
+Or inline from the project root:
+
+```bash
+cd docthu
+python - << 'EOF'
+from pathlib import Path
+from docthu import Template
+
+tpl = Template(Path("examples/shopee/template.html").read_text())
+
+for name in ["test1", "test2", "test3"]:
+    msg = Path(f"examples/shopee/{name}.html").read_text()
+    print(f"\n--- {name} ---")
+    import json
+    print(json.dumps(tpl.match(msg), indent=2, ensure_ascii=False, default=str))
+EOF
+```
+
+### Early exit (fast path)
+
+If you only need the order ID and total, use `stop_on_filled` to skip parsing the rest of the document:
+
+```python
+result = tpl.match(message, stop_on_filled=["order_id", "total"])
+```
+
+### Expected output
+
+**test1.html** — 2 items, no coupon
+
+```json
+{
+  "order_id": "2401ABCD123456",
+  "order_date": "2024-01-01 00:00:00",
+  "seller": "9m.2m",
+  "item": [
+    {
+      "number": "1",
+      "name": "Cà Phê Arabica Sơn La Natural | Cà phê rang xay nguyên chất phù hợp pha pour over V60 trái cây",
+      "variant": "250gr - Rang Light,Nguyên hạt",
+      "quantity": 1,
+      "price": 120000.0
+    },
+    {
+      "number": "2",
+      "name": "Cà Phê Arabica Sơn La | Cà phê rang xay nguyên chất phù hợp pha pour over V60 trái cây",
+      "variant": "250gr - Light Roast,Nguyên hạt",
+      "quantity": 1,
+      "price": 80000.0
+    }
+  ],
+  "total": 200000.0
+}
+```
+
+**test2.html** — 1 item, Shopee + Shop coupons applied
+
+```json
+{
+  "order_id": "2401EFGH789012",
+  "order_date": "2024-01-01 00:00:00",
+  "seller": "vbinhshop",
+  "item": [
+    {
+      "number": "1",
+      "name": "Máy xay cafe cầm tay cối xay cafe mini Chất Lượng cối xay cà phê Cao CNC 6 trục",
+      "variant": "VBZ18-MàuBạc",
+      "quantity": 1,
+      "price": 800000.0
+    }
+  ],
+  "total": 670000.0
+}
+```
+
+**test3.html** — 1 item, Shopee coupon applied
+
+```json
+{
+  "order_id": "2401IJKL345678",
+  "order_date": "2024-01-01 00:00:00",
+  "seller": "mujivn.official",
+  "item": [
+    {
+      "number": "1",
+      "name": "Áo Khoác Hoodie Nam Khóa Kéo Gấp Gọn Chống Tia Uv Nhanh Khô MUJI",
+      "variant": "Xám nhạt,M",
+      "quantity": 1,
+      "price": 500000.0
+    }
+  ],
+  "total": 450000.0
+}
+```

--- a/examples/shopee/template.html
+++ b/examples/shopee/template.html
@@ -1,0 +1,1360 @@
+
+
+<!doctype html>
+<html>
+<head>
+    <title>Đơn hàng #{{ _title_order_id }} đã giao hàng thành công</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+    
+<style type="text/css">
+    .base_font {
+        font-family: Helvetica, arial, sans-serif !important;
+        font-size: 13px;
+        color:#000000;
+    }
+    .orange {
+        color:#ff5722 !important;
+    }
+    .bg_orange {
+        background-color:#ff5722;
+    }
+    .white {
+        color:white;
+    }
+    .caret_right {
+        border-top: 4px solid transparent;
+        border-bottom: 4px solid transparent;
+        border-left: 4px solid white;
+        display: inline-block;
+        height: 0;
+        vertical-align: middle;
+        width: 0;
+    }
+    .text_align_left {
+        text-align: left;
+    }
+    html {
+        --lh: 18px;
+        line-height: var(--lh);
+    }
+    .overflow {
+        --max-lines: 2;
+        position: relative;
+        max-height: calc(var(--lh) * var(--max-lines));
+        min-height: calc(var(--lh) * var(--max-lines));
+        height: calc(var(--lh) * var(--max-lines));
+        overflow: hidden;
+    }
+    .overflow::before {
+        position: absolute;
+        content: "...";
+         
+        bottom: 0;
+        right: 0;
+    }
+    .overflow::after {
+        content: "";
+        position: absolute;
+         
+        right: 0;
+        width: 1rem;
+        height: 1rem;
+    }
+    .link {text-decoration:none;color:#ff5722;}
+
+     
+    div, p, a, li, td { -webkit-text-size-adjust:none; }
+    #outlook a {padding:0;}  
+    html{width: 100%; }
+    body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;}
+     
+    .ExternalClass {width:100%;}  
+    .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}  
+    #backgroundTable {margin:0; padding:0; width:100% !important; line-height: 100% !important;}
+    img {outline:none; text-decoration:none;border:none; -ms-interpolation-mode: bicubic;}
+    a img {border:none;}
+    .image_fix {display:block;}
+    p {margin: 0px 0px !important;}
+    table td {border-collapse: collapse;}
+    table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+    a {color: #33b9ff;text-decoration: none;text-decoration:none!important;}
+     
+    table[class=full] { width: 100%; clear: both; }
+    .textstyle { text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top; width:280px; }
+    .titlestyle { text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold; }
+
+     
+    @media only screen and (max-width: 640px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 440px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 420px!important;text-align:center!important;}
+        .devicecolumn {width:210px;min-width:210px;max-width:210px;}
+        .footercolumn {width:80px;min-width:80px;max-width:80px;display:block!important;}    
+        img[class=banner] {width: 440px!important;height:220px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 132px!important;height:132px!important;}
+
+    }
+     
+     
+    @media only screen and (min-width: 320px) and (max-width: 480px)  and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media only screen and (min-width: 320px) and (max-width: 568px) and (-webkit-min-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+     
+    @media only screen and (min-width: 375px) and (max-width: 667px) and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:157px;min-width:157px;max-width:157px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 95px!important;height:95px!important;}
+
+    }
+     
+    @media only screen and (min-width: 414px) and (max-width: 736px) and (-webkit-min-device-pixel-ratio: 3){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 110px!important;height:110px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;display:block!important;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:320px!important;}
+         
+        img[class=col2img] {width: 160px!important;height:160px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+
+     
+    @media screen and (device-width: 320px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 740px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 320px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 400px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 360px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 340px!important;text-align:center!important;}
+        .devicecolumn {width:180px;min-width:180px;max-width:180px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 360px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 412px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 372px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 352px!important;text-align:center!important;}
+        .devicecolumn {width:186px;min-width:186px;max-width:186px;}
+        .footercolumn {width:65px;min-width:65px;max-width:65px;display:block!important;}    
+        img[class=banner] {width: 372px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (min-device-width: 392px) and (max-device-width: 393px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 352px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 332px!important;text-align:center!important;}
+        .devicecolumn {width:176px;min-width:176px;max-width:176px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 352px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+</style>
+
+</head>
+<body><img alt="" src="{{ _tracking_pixel }}" width="1" height="1">
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td align="center"><img src="https://cf.shopee.sg/file/0cd023d64f04491f3dc8076d6932dfdc" width="140" height="auto" style="width: 25%;height: auto;"></td>
+                                        </tr>
+                                        
+                                        
+                                        
+                                        <tr>
+                                            <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        Xin chào {{ _username }},
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Đơn hàng <a
+                href="{{ _intro_order_link }}"
+                target="_blank" style="text-decoration:none;color:#ff5722">#{{ _intro_order_id }}</a> của bạn đã được giao thành
+        công ngày {{ _delivery_date }}. <br/><br/>
+        Vui lòng đăng nhập Shopee để xác nhận bạn đã nhận hàng và hài lòng với sản phẩm trong
+        vòng 3 ngày. Sau khi bạn xác nhận, chúng tôi sẽ
+        thanh toán cho Người bán <a
+                href="{{ _intro_seller_link }}"
+                target="_blank" style="text-decoration:none;color:#ff5722">{{ _intro_seller }}</a>.
+        <br/>
+        Nếu bạn không xác nhận trong khoảng thời gian này, Shopee cũng sẽ thanh toán cho Người bán.
+
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#EE4D2D" style="padding: 8px 30px 8px 30px; border-radius:3px" align="center"><a
+                            href="{{ _button_link }}"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; display: inline-block;">
+                        Đã nhận hàng </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+    
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif;  color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+    </tr>
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold;">
+            THÔNG TIN ĐƠN HÀNG - DÀNH CHO NGƯỜI MUA
+        </td>
+    </tr>
+    
+    
+    <tr>
+        <td height="" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;" width="100%">&nbsp;</td>
+    </tr>
+    
+    
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+    
+
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Mã đơn hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">
+                
+                    <a class="devicecolumn" href="{{ _order_link }}"
+                       style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;" target="_blank">#{{ order_id }}</a>
+                
+            </td>
+        </tr>
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Ngày đặt hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">{{ order_date:datetime }}
+            </td>
+        </tr>
+        
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Người bán:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%"><a
+                                class="devicecolumn"
+                                href="{{ _seller_link }}"
+                                style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;"
+                                target="_blank">{{ seller }}</a></td>
+                </tr>
+            
+        
+        
+        <tr>
+            <td colspan="2" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;"
+                width="100%">
+                &nbsp;
+            </td>
+        </tr>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+
+        
+    
+        
+
+{% list: item %}
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        
+        <table width="560" align="center" border="0" cellpadding="0" cellspacing="0" class="devicewidthinner">
+            <tbody>
+            
+            <tr>
+                <td width="560" height="140" align="left" class="devicewidth">
+                    
+                        <a href="{{ item.link }}">
+                            <img src="{{ item.image }}" alt="" border="0" width="140" height="140" style="display:block; border:none; outline:none; text-decoration:none;" class="col2img">
+                        </a>
+                    
+                </td>
+            </tr>
+            
+            </tbody>
+        </table>
+        
+        
+        <table align="left" border="0" cellpadding="0" cellspacing="0" class="mobilespacing">
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner" style="table-layout:fixed">
+            <tr>
+                <td colspan="2" width="" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+            </tr>
+            <tr>
+                <td colspan="2" style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left">
+                    
+                        {{ item.number }}.
+                        
+                            {{ item.name }}
+                        
+                    
+                </td>
+            </tr>
+
+              
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Mẫu mã: </td>
+                    
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">{{ item.variant }}</td>
+                    
+                </tr>
+                
+                
+                    <tr>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Số lượng: </td>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">{{ item.quantity:int }}</td>
+                    </tr>
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Giá: </td>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">₫{{ item.price:float }}</td>
+                </tr>
+
+             
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+{% end %}
+
+
+
+        
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner"
+               style="table-layout:fixed">
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng tiền:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">
+                    {{ _skip }}Tổng thanh toán:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫{{ total:float }}
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            
+            
+        </table>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-weight:bold;font-size: 13px; color: #1f1f1f; text-align:left; line-height: 18px;">
+        BƯỚC TIẾP THEO
+    </td>
+</tr>
+
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Bạn không hài lòng về sản phẩm? <br/>
+        Bạn có thể gửi <a
+                href="{{ _return_link2 }}"
+                style="text-decoration:none;color:#ff5722;">yêu cầu trả hàng</a> trên ứng dụng Shopee trong
+        vòng 3 ngày kể từ khi nhận được email
+        này.<br/><br/>
+
+        Lưu ý: Shopee sẽ từ chối hỗ trợ các khiếu nại sau khi Người mua nhấn "Đã nhận được hàng" trên ứng dụng và Người
+        bán đã nhận được thanh toán cho đơn hàng. <br/><br/>
+
+        Tìm hiểu thêm về chính sách <a
+                href="https://help.shopee.vn/vn/s/topic/0TO6F000000QzKHWA0/tr%E1%BA%A3-h%C3%A0ng-ho%C3%A0n-ti%E1%BB%81n"
+                style="text-decoration:none;color:#ff5722;" target="_blank">Trả hàng/Hoàn tiền</a> của Shopee.
+        <br/><br/>
+        Chúc bạn luôn có những trải nghiệm tuyệt vời khi mua sắm tại Shopee.
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#ffffff"
+                    style="border: 2px solid;border-color: #EE4D2D; padding: 8px 13px 8px 13px; border-radius:3px"
+                    align="center"><a
+                            href="{{ _return_link }}"
+                            target="_blank"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #EE4D2D; text-decoration: none; display: inline-block;">
+                        Trả hàng/Hoàn tiền </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+<br/>
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        <br/>
+        Trân trọng,<br/>
+        Đội ngũ Shopee
+    </td>
+</tr>
+
+                                          
+    <tr>
+        <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+            <br/>
+            Bạn có thắc mắc? Liên hệ chúng tôi <a href="https://shopee.vn/universal-link?redir=https%3A%2F%2Fhelp.shopee.vn%2Fportal%3Fsmtt%3D9&smtt=9&deep_and_deferred=1" style="text-decoration:underline!important;color:#ff5722" target="_blank">tại đây</a>.
+        </td>
+    </tr>
+
+                                     
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    
+
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr><td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #747474; text-align:center; line-height: 18px;">
+                                                Hãy mua sắm cùng Shopee
+                                            </td></tr>
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td width="160"></td>
+                                                <td width="130"><a href="https://play.google.com/store/apps/details?id=com.shopee.vn"><img src="https://cf.shopee.sg/file/cacc3e27277d02501b0989fdcbaf18e9" width="130" style="width:130px;"></a></td>
+                                                <td width="5"></td>
+                                                <td width="130"><a href="https://apps.apple.com/vn/app/id959841449"><img src="https://cf.shopee.sg/file/5b4dcec6c9c60950954b465bafee9cff" width="130" style="width:130px;"></a></td>
+                                                <td width="160"></td>
+                                            </tr>
+                                        </table>
+                                        
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:5px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+    </div>
+</div>
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly; text-overflow: ellipsis;color:#ffffff">&nbsp;</td>
+                                        </tr>
+                                        <tr>
+                                            <td width="112" ></td>
+                                            <td width="112" align="center">
+                                                <a href="https://vi-vn.facebook.com/ShopeeVN/"><img src="https://f.shopee.sg/file/3814109aa6a3721b577919d5c8a36cfe" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.instagram.com/shopee_vn/"><img src="https://f.shopee.sg/file/3b08ded58cbbb9beb74ec4d5ad4c7d53" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.youtube.com/channel/UCKcxoGpxOJx3nt83MCG-nuQ"><img src="https://f.shopee.sg/file/e7ab71dae1223ca9eb4b9f120353a31e" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" ></td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:15px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+        &nbsp;
+    </div>
+</div>
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;"><a href="https://shopee.vn/docs/3603" target="_blank" style="text-decoration:none;color:#ff5722">Chính sách bảo mật</a> | <a href="https://shopee.vn/legaldoc/policies/" target="_blank" style="text-decoration:none;color:#ff5722">Điều khoản Shopee</a></td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Đây là email tự động. Vui lòng không trả lời email này. Thêm <a href="mailto:info@mail.shopee.vn" target="_blank" style="text-decoration:none;color:#ff5722">info@mail.shopee.vn</a> vào danh bạ email của bạn để đảm bảo bạn luôn nhận được email từ chúng tôi.</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Tầng 17 Saigon Centre 2, 67 Đường Lê Lợi, Bến Nghé, Quận 1, Hồ Chí Minh 700000, Vietnam</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="40" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+<div style="white-space:nowrap!important;line-height: 0; color: #ffffff;">
+    - - - - - - - - - - - - - - - - - - - - - - - -  - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+</div>
+</body>
+</html>
+

--- a/examples/shopee/test1.html
+++ b/examples/shopee/test1.html
@@ -1,0 +1,1500 @@
+
+
+<!doctype html>
+<html>
+<head>
+    <title>Đơn hàng #2401ABCD123456 đã giao hàng thành công</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+    
+<style type="text/css">
+    .base_font {
+        font-family: Helvetica, arial, sans-serif !important;
+        font-size: 13px;
+        color:#000000;
+    }
+    .orange {
+        color:#ff5722 !important;
+    }
+    .bg_orange {
+        background-color:#ff5722;
+    }
+    .white {
+        color:white;
+    }
+    .caret_right {
+        border-top: 4px solid transparent;
+        border-bottom: 4px solid transparent;
+        border-left: 4px solid white;
+        display: inline-block;
+        height: 0;
+        vertical-align: middle;
+        width: 0;
+    }
+    .text_align_left {
+        text-align: left;
+    }
+    html {
+        --lh: 18px;
+        line-height: var(--lh);
+    }
+    .overflow {
+        --max-lines: 2;
+        position: relative;
+        max-height: calc(var(--lh) * var(--max-lines));
+        min-height: calc(var(--lh) * var(--max-lines));
+        height: calc(var(--lh) * var(--max-lines));
+        overflow: hidden;
+    }
+    .overflow::before {
+        position: absolute;
+        content: "...";
+         
+        bottom: 0;
+        right: 0;
+    }
+    .overflow::after {
+        content: "";
+        position: absolute;
+         
+        right: 0;
+        width: 1rem;
+        height: 1rem;
+    }
+    .link {text-decoration:none;color:#ff5722;}
+
+     
+    div, p, a, li, td { -webkit-text-size-adjust:none; }
+    #outlook a {padding:0;}  
+    html{width: 100%; }
+    body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;}
+     
+    .ExternalClass {width:100%;}  
+    .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}  
+    #backgroundTable {margin:0; padding:0; width:100% !important; line-height: 100% !important;}
+    img {outline:none; text-decoration:none;border:none; -ms-interpolation-mode: bicubic;}
+    a img {border:none;}
+    .image_fix {display:block;}
+    p {margin: 0px 0px !important;}
+    table td {border-collapse: collapse;}
+    table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+    a {color: #33b9ff;text-decoration: none;text-decoration:none!important;}
+     
+    table[class=full] { width: 100%; clear: both; }
+    .textstyle { text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top; width:280px; }
+    .titlestyle { text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold; }
+
+     
+    @media only screen and (max-width: 640px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 440px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 420px!important;text-align:center!important;}
+        .devicecolumn {width:210px;min-width:210px;max-width:210px;}
+        .footercolumn {width:80px;min-width:80px;max-width:80px;display:block!important;}    
+        img[class=banner] {width: 440px!important;height:220px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 132px!important;height:132px!important;}
+
+    }
+     
+     
+    @media only screen and (min-width: 320px) and (max-width: 480px)  and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media only screen and (min-width: 320px) and (max-width: 568px) and (-webkit-min-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+     
+    @media only screen and (min-width: 375px) and (max-width: 667px) and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:157px;min-width:157px;max-width:157px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 95px!important;height:95px!important;}
+
+    }
+     
+    @media only screen and (min-width: 414px) and (max-width: 736px) and (-webkit-min-device-pixel-ratio: 3){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 110px!important;height:110px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;display:block!important;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:320px!important;}
+         
+        img[class=col2img] {width: 160px!important;height:160px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+
+     
+    @media screen and (device-width: 320px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 740px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 320px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 400px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 360px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 340px!important;text-align:center!important;}
+        .devicecolumn {width:180px;min-width:180px;max-width:180px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 360px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 412px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 372px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 352px!important;text-align:center!important;}
+        .devicecolumn {width:186px;min-width:186px;max-width:186px;}
+        .footercolumn {width:65px;min-width:65px;max-width:65px;display:block!important;}    
+        img[class=banner] {width: 372px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (min-device-width: 392px) and (max-device-width: 393px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 352px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 332px!important;text-align:center!important;}
+        .devicecolumn {width:176px;min-width:176px;max-width:176px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 352px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+</style>
+
+</head>
+<body><img alt="" src="https://tracking.mail.shopee.vn/tracking/1/open/_fzFogbGZ8_V2-I_lw8UXJtL6ZrIrX99Bdsv-h5VTkT5viq_2ZJXQqzC4HAR4kYGU2HisGuMQtWHQ6ElwhoEZYkHavmxw8XCzL-7g0IrHhUYow5xXSuYyUA1DDY3oJ6XM2cxuPoRjO-eUObdhYB1SjPoy2jvuj42VxjPS7m2O23WdLueGxuJCEV20tZpgdrxZVVB_cRxceU7IkXk3aPNE9JKc34IVewxSH0fmfRxwAI0M4BeX9p57J_b634css9xnwd6uQ1tNN15eoIWtBiandov_SdW_KM5T3w4FdEgvAqq9SH6pslXwp7NrFzQPwAkmoEHkAdXvvP94EL26bofLkgLKOxKmrBSEGexkzAJn9k=" width="1" height="1">
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td align="center"><img src="https://cf.shopee.sg/file/0cd023d64f04491f3dc8076d6932dfdc" width="140" height="auto" style="width: 25%;height: auto;"></td>
+                                        </tr>
+                                        
+                                        
+                                        
+                                        <tr>
+                                            <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        Xin chào alice_nguyen,
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Đơn hàng <a
+                href="https://shopee.vn/universal-link/user/purchase/order/100000000000001/?shopid=975949949&deep_and_deferred=1&smtt=580.47822344.7"
+                target="_blank" style="text-decoration:none;color:#ff5722">#2401ABCD123456</a> của bạn đã được giao thành
+        công ngày 03/01/2024. <br/><br/>
+        Vui lòng đăng nhập Shopee để xác nhận bạn đã nhận hàng và hài lòng với sản phẩm trong
+        vòng 3 ngày. Sau khi bạn xác nhận, chúng tôi sẽ
+        thanh toán cho Người bán <a
+                href="https://shopee.vn/universal-link/9m.2m?smtt=580.47822344.7"
+                target="_blank" style="text-decoration:none;color:#ff5722">9m.2m</a>.
+        <br/>
+        Nếu bạn không xác nhận trong khoảng thời gian này, Shopee cũng sẽ thanh toán cho Người bán.
+
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#EE4D2D" style="padding: 8px 30px 8px 30px; border-radius:3px" align="center"><a
+                            href="https://shopee.vn/universal-link/user/purchase/order/100000000000001/?shopid=975949949&deep_and_deferred=1&smtt=580.47822344.7"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; display: inline-block;">
+                        Đã nhận hàng </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+    
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif;  color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+    </tr>
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold;">
+            THÔNG TIN ĐƠN HÀNG - DÀNH CHO NGƯỜI MUA
+        </td>
+    </tr>
+    
+    
+    <tr>
+        <td height="" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;" width="100%">&nbsp;</td>
+    </tr>
+    
+    
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+    
+
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Mã đơn hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">
+                
+                    <a class="devicecolumn" href="https://shopee.vn/universal-link/user/purchase/order/100000000000001/?shopid=975949949&deep_and_deferred=1&smtt=580.47822344.7"
+                       style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;" target="_blank">#2401ABCD123456</a>
+                
+            </td>
+        </tr>
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Ngày đặt hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">01/01/2024 00:00:00
+            </td>
+        </tr>
+        
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Người bán:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%"><a
+                                class="devicecolumn"
+                                href="https://shopee.vn/universal-link/9m.2m?smtt=580.47822344.7"
+                                style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;"
+                                target="_blank">9m.2m</a></td>
+                </tr>
+            
+        
+        
+        <tr>
+            <td colspan="2" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;"
+                width="100%">
+                &nbsp;
+            </td>
+        </tr>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+
+        
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        
+        <table width="560" align="center" border="0" cellpadding="0" cellspacing="0" class="devicewidthinner">
+            <tbody>
+            
+            <tr>
+                <td width="560" height="140" align="left" class="devicewidth">
+                    
+                        <a href="https://shopee.vn/universal-link/C%C3%A0&#43;Ph%C3%AA&#43;Arabica&#43;S%C6%A1n&#43;La&#43;Natural&#43;%7C&#43;C%C3%A0&#43;ph%C3%AA&#43;rang&#43;xay&#43;nguy%C3%AAn&#43;ch%E1%BA%A5t&#43;ph%C3%B9&#43;h%E1%BB%A3p&#43;pha&#43;pour&#43;over&#43;V60&#43;tr%C3%A1i&#43;c%C3%A2y-i.975949949.24459566832/?smtt=580.47822344.7">
+                            <img src="https://cf.shopee.vn/file/vn-11134207-7r98o-lqpxtl85lb6a0e" alt="" border="0" width="140" height="140" style="display:block; border:none; outline:none; text-decoration:none;" class="col2img">
+                        </a>
+                    
+                </td>
+            </tr>
+            
+            </tbody>
+        </table>
+        
+        
+        <table align="left" border="0" cellpadding="0" cellspacing="0" class="mobilespacing">
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner" style="table-layout:fixed">
+            <tr>
+                <td colspan="2" width="" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+            </tr>
+            <tr>
+                <td colspan="2" style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left">
+                    
+                        1.
+                        
+                            Cà Phê Arabica Sơn La Natural | Cà phê rang xay nguyên chất phù hợp pha pour over V60 trái cây
+                        
+                    
+                </td>
+            </tr>
+
+              
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Mẫu mã: </td>
+                    
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">250gr - Rang Light,Nguyên hạt</td>
+                    
+                </tr>
+                
+                
+                    <tr>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Số lượng: </td>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">1</td>
+                    </tr>
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Giá: </td>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">₫120,000</td>
+                </tr>
+
+             
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        
+        <table width="560" align="center" border="0" cellpadding="0" cellspacing="0" class="devicewidthinner">
+            <tbody>
+            
+            <tr>
+                <td width="560" height="140" align="left" class="devicewidth">
+                    
+                        <a href="https://shopee.vn/universal-link/C%C3%A0&#43;Ph%C3%AA&#43;Arabica&#43;S%C6%A1n&#43;La&#43;%7C&#43;C%C3%A0&#43;ph%C3%AA&#43;rang&#43;xay&#43;nguy%C3%AAn&#43;ch%E1%BA%A5t&#43;ph%C3%B9&#43;h%E1%BB%A3p&#43;pha&#43;pour&#43;over&#43;V60&#43;tr%C3%A1i&#43;c%C3%A2y-i.975949949.20581131114/?smtt=580.47822344.7">
+                            <img src="https://cf.shopee.vn/file/vn-11134207-7qukw-libbs7iiroy463" alt="" border="0" width="140" height="140" style="display:block; border:none; outline:none; text-decoration:none;" class="col2img">
+                        </a>
+                    
+                </td>
+            </tr>
+            
+            </tbody>
+        </table>
+        
+        
+        <table align="left" border="0" cellpadding="0" cellspacing="0" class="mobilespacing">
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner" style="table-layout:fixed">
+            <tr>
+                <td colspan="2" width="" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+            </tr>
+            <tr>
+                <td colspan="2" style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left">
+                    
+                        2.
+                        
+                            Cà Phê Arabica Sơn La | Cà phê rang xay nguyên chất phù hợp pha pour over V60 trái cây
+                        
+                    
+                </td>
+            </tr>
+
+              
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Mẫu mã: </td>
+                    
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">250gr - Light Roast,Nguyên hạt</td>
+                    
+                </tr>
+                
+                
+                    <tr>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Số lượng: </td>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">1</td>
+                    </tr>
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Giá: </td>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">₫80,000</td>
+                </tr>
+
+             
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+        
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner"
+               style="table-layout:fixed">
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng tiền:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">
+                    ₫200,000
+                </td>
+            </tr>
+            
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Phí vận chuyển:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫0
+                </td>
+            </tr>
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng thanh toán:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫200,000
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            
+            
+        </table>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-weight:bold;font-size: 13px; color: #1f1f1f; text-align:left; line-height: 18px;">
+        BƯỚC TIẾP THEO
+    </td>
+</tr>
+
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Bạn không hài lòng về sản phẩm? <br/>
+        Bạn có thể gửi <a
+                href="https://shopee.vn/universal-link/user/purchase/order/100000000000001/?shopid=975949949&deep_and_deferred=1&smtt=580.47822344.7"
+                style="text-decoration:none;color:#ff5722;">yêu cầu trả hàng</a> trên ứng dụng Shopee trong
+        vòng 3 ngày kể từ khi nhận được email
+        này.<br/><br/>
+
+        Lưu ý: Shopee sẽ từ chối hỗ trợ các khiếu nại sau khi Người mua nhấn "Đã nhận được hàng" trên ứng dụng và Người
+        bán đã nhận được thanh toán cho đơn hàng. <br/><br/>
+
+        Tìm hiểu thêm về chính sách <a
+                href="https://help.shopee.vn/vn/s/topic/0TO6F000000QzKHWA0/tr%E1%BA%A3-h%C3%A0ng-ho%C3%A0n-ti%E1%BB%81n"
+                style="text-decoration:none;color:#ff5722;" target="_blank">Trả hàng/Hoàn tiền</a> của Shopee.
+        <br/><br/>
+        Chúc bạn luôn có những trải nghiệm tuyệt vời khi mua sắm tại Shopee.
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#ffffff"
+                    style="border: 2px solid;border-color: #EE4D2D; padding: 8px 13px 8px 13px; border-radius:3px"
+                    align="center"><a
+                            href="https://shopee.vn/universal-link/user/purchase/order/100000000000001/?shopid=975949949&deep_and_deferred=1&smtt=580.47822344.7"
+                            target="_blank"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #EE4D2D; text-decoration: none; display: inline-block;">
+                        Trả hàng/Hoàn tiền </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+<br/>
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        <br/>
+        Trân trọng,<br/>
+        Đội ngũ Shopee
+    </td>
+</tr>
+
+                                          
+    <tr>
+        <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+            <br/>
+            Bạn có thắc mắc? Liên hệ chúng tôi <a href="https://shopee.vn/universal-link?redir=https%3A%2F%2Fhelp.shopee.vn%2Fportal%3Fsmtt%3D9&smtt=9&deep_and_deferred=1" style="text-decoration:underline!important;color:#ff5722" target="_blank">tại đây</a>.
+        </td>
+    </tr>
+
+                                     
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    
+
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr><td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #747474; text-align:center; line-height: 18px;">
+                                                Hãy mua sắm cùng Shopee
+                                            </td></tr>
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td width="160"></td>
+                                                <td width="130"><a href="https://play.google.com/store/apps/details?id=com.shopee.vn"><img src="https://cf.shopee.sg/file/cacc3e27277d02501b0989fdcbaf18e9" width="130" style="width:130px;"></a></td>
+                                                <td width="5"></td>
+                                                <td width="130"><a href="https://apps.apple.com/vn/app/id959841449"><img src="https://cf.shopee.sg/file/5b4dcec6c9c60950954b465bafee9cff" width="130" style="width:130px;"></a></td>
+                                                <td width="160"></td>
+                                            </tr>
+                                        </table>
+                                        
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:5px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+    </div>
+</div>
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly; text-overflow: ellipsis;color:#ffffff">&nbsp;</td>
+                                        </tr>
+                                        <tr>
+                                            <td width="112" ></td>
+                                            <td width="112" align="center">
+                                                <a href="https://vi-vn.facebook.com/ShopeeVN/"><img src="https://f.shopee.sg/file/3814109aa6a3721b577919d5c8a36cfe" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.instagram.com/shopee_vn/"><img src="https://f.shopee.sg/file/3b08ded58cbbb9beb74ec4d5ad4c7d53" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.youtube.com/channel/UCKcxoGpxOJx3nt83MCG-nuQ"><img src="https://f.shopee.sg/file/e7ab71dae1223ca9eb4b9f120353a31e" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" ></td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:15px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+        &nbsp;
+    </div>
+</div>
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;"><a href="https://shopee.vn/docs/3603" target="_blank" style="text-decoration:none;color:#ff5722">Chính sách bảo mật</a> | <a href="https://shopee.vn/legaldoc/policies/" target="_blank" style="text-decoration:none;color:#ff5722">Điều khoản Shopee</a></td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Đây là email tự động. Vui lòng không trả lời email này. Thêm <a href="mailto:info@mail.shopee.vn" target="_blank" style="text-decoration:none;color:#ff5722">info@mail.shopee.vn</a> vào danh bạ email của bạn để đảm bảo bạn luôn nhận được email từ chúng tôi.</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Tầng 17 Saigon Centre 2, 67 Đường Lê Lợi, Bến Nghé, Quận 1, Hồ Chí Minh 700000, Vietnam</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="40" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+<div style="white-space:nowrap!important;line-height: 0; color: #ffffff;">
+    - - - - - - - - - - - - - - - - - - - - - - - -  - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+</div>
+</body>
+</html>
+

--- a/examples/shopee/test2.html
+++ b/examples/shopee/test2.html
@@ -1,0 +1,1426 @@
+
+
+<!doctype html>
+<html>
+<head>
+    <title>Đơn hàng #2401EFGH789012 đã giao hàng thành công</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+    
+<style type="text/css">
+    .base_font {
+        font-family: Helvetica, arial, sans-serif !important;
+        font-size: 13px;
+        color:#000000;
+    }
+    .orange {
+        color:#ff5722 !important;
+    }
+    .bg_orange {
+        background-color:#ff5722;
+    }
+    .white {
+        color:white;
+    }
+    .caret_right {
+        border-top: 4px solid transparent;
+        border-bottom: 4px solid transparent;
+        border-left: 4px solid white;
+        display: inline-block;
+        height: 0;
+        vertical-align: middle;
+        width: 0;
+    }
+    .text_align_left {
+        text-align: left;
+    }
+    html {
+        --lh: 18px;
+        line-height: var(--lh);
+    }
+    .overflow {
+        --max-lines: 2;
+        position: relative;
+        max-height: calc(var(--lh) * var(--max-lines));
+        min-height: calc(var(--lh) * var(--max-lines));
+        height: calc(var(--lh) * var(--max-lines));
+        overflow: hidden;
+    }
+    .overflow::before {
+        position: absolute;
+        content: "...";
+         
+        bottom: 0;
+        right: 0;
+    }
+    .overflow::after {
+        content: "";
+        position: absolute;
+         
+        right: 0;
+        width: 1rem;
+        height: 1rem;
+    }
+    .link {text-decoration:none;color:#ff5722;}
+
+     
+    div, p, a, li, td { -webkit-text-size-adjust:none; }
+    #outlook a {padding:0;}  
+    html{width: 100%; }
+    body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;}
+     
+    .ExternalClass {width:100%;}  
+    .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}  
+    #backgroundTable {margin:0; padding:0; width:100% !important; line-height: 100% !important;}
+    img {outline:none; text-decoration:none;border:none; -ms-interpolation-mode: bicubic;}
+    a img {border:none;}
+    .image_fix {display:block;}
+    p {margin: 0px 0px !important;}
+    table td {border-collapse: collapse;}
+    table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+    a {color: #33b9ff;text-decoration: none;text-decoration:none!important;}
+     
+    table[class=full] { width: 100%; clear: both; }
+    .textstyle { text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top; width:280px; }
+    .titlestyle { text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold; }
+
+     
+    @media only screen and (max-width: 640px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 440px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 420px!important;text-align:center!important;}
+        .devicecolumn {width:210px;min-width:210px;max-width:210px;}
+        .footercolumn {width:80px;min-width:80px;max-width:80px;display:block!important;}    
+        img[class=banner] {width: 440px!important;height:220px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 132px!important;height:132px!important;}
+
+    }
+     
+     
+    @media only screen and (min-width: 320px) and (max-width: 480px)  and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media only screen and (min-width: 320px) and (max-width: 568px) and (-webkit-min-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+     
+    @media only screen and (min-width: 375px) and (max-width: 667px) and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:157px;min-width:157px;max-width:157px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 95px!important;height:95px!important;}
+
+    }
+     
+    @media only screen and (min-width: 414px) and (max-width: 736px) and (-webkit-min-device-pixel-ratio: 3){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 110px!important;height:110px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;display:block!important;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:320px!important;}
+         
+        img[class=col2img] {width: 160px!important;height:160px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+
+     
+    @media screen and (device-width: 320px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 740px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 320px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 400px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 360px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 340px!important;text-align:center!important;}
+        .devicecolumn {width:180px;min-width:180px;max-width:180px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 360px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 412px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 372px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 352px!important;text-align:center!important;}
+        .devicecolumn {width:186px;min-width:186px;max-width:186px;}
+        .footercolumn {width:65px;min-width:65px;max-width:65px;display:block!important;}    
+        img[class=banner] {width: 372px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (min-device-width: 392px) and (max-device-width: 393px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 352px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 332px!important;text-align:center!important;}
+        .devicecolumn {width:176px;min-width:176px;max-width:176px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 352px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+</style>
+
+</head>
+<body><img alt="" src="https://tracking.mail.shopee.vn/tracking/1/open/_iWO_vdKi_16iyOfzkYV7n6Sd2p5wlJnDcgw-sd0xFMfWU_9Sg_pcj1kiWAVVdTgpyYJ0pCthX4xR24QWxNpuKUcqIqgR5m42lVHnr_dDkA9u0dFS5yUDNav6UJhdquDmizSRzuZ1oWgQL-_MjOt9uxe7T4_j036XQAZrVUslXs_OMxe89qXzYMoYyfuc39bn7B_SLzKY2Bl-aqcam1aPRvUbklnmmLJpGvSkUBl4P9B3GnluHYBV5OTGWy6qKZVrHP15wdbYso8SY-1oYM5W2OtvZdZnUOyAwjP9RQblQBp_sq3y_Eo-Augp6kBTQLWQH4wdAAs8VPC3EQEYKxgDFo1g2tmAvCTXlxSbOdwWOli09EJiby87iE10tFXwMVE5z2p9mh-Ipe9TtcgwLiUylLNJ_ubFszempkAiukmFNW5kpbfJjGsSY36QCQgSHr7krDhqwRT4U-Z5JxyzQ3OO-eRmDsRw_u3YR9q5ebyqjUXrVFn4kVNp5JBE4wuPtgmgh20pAZpVfqpft12he-HaCU_XOjJw0aRgZK1TkIX2OKE0Tb43VVsDE1hUGiC68XA9Vy82ZRH-Ui5fU5tuklGi-jqKp9pBk8I2lF9z88lEXM=" width="1" height="1">
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td align="center"><img src="https://cf.shopee.sg/file/0cd023d64f04491f3dc8076d6932dfdc" width="140" height="auto" style="width: 25%;height: auto;"></td>
+                                        </tr>
+                                        
+                                        
+                                        
+                                        <tr>
+                                            <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        Xin chào bob_tran,
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Đơn hàng <a
+                href="https://shopee.vn/universal-link/user/purchase/order/100000000000002/?shopid=405225863&deep_and_deferred=1&smtt=580.47822344.7"
+                target="_blank" style="text-decoration:none;color:#ff5722">#2401EFGH789012</a> của bạn đã được giao thành
+        công ngày 03/01/2024. <br/><br/>
+        Vui lòng đăng nhập Shopee để xác nhận bạn đã nhận hàng và hài lòng với sản phẩm trong
+        vòng 3 ngày. Sau khi bạn xác nhận, chúng tôi sẽ
+        thanh toán cho Người bán <a
+                href="https://shopee.vn/universal-link/vbinhshop?smtt=580.47822344.7"
+                target="_blank" style="text-decoration:none;color:#ff5722">vbinhshop</a>.
+        <br/>
+        Nếu bạn không xác nhận trong khoảng thời gian này, Shopee cũng sẽ thanh toán cho Người bán.
+
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#EE4D2D" style="padding: 8px 30px 8px 30px; border-radius:3px" align="center"><a
+                            href="https://shopee.vn/universal-link/user/purchase/order/100000000000002/?shopid=405225863&deep_and_deferred=1&smtt=580.47822344.7"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; display: inline-block;">
+                        Đã nhận hàng </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+    
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif;  color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+    </tr>
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold;">
+            THÔNG TIN ĐƠN HÀNG - DÀNH CHO NGƯỜI MUA
+        </td>
+    </tr>
+    
+    
+    <tr>
+        <td height="" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;" width="100%">&nbsp;</td>
+    </tr>
+    
+    
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+    
+
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Mã đơn hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">
+                
+                    <a class="devicecolumn" href="https://shopee.vn/universal-link/user/purchase/order/100000000000002/?shopid=405225863&deep_and_deferred=1&smtt=580.47822344.7"
+                       style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;" target="_blank">#2401EFGH789012</a>
+                
+            </td>
+        </tr>
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Ngày đặt hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">01/01/2024 00:00:00
+            </td>
+        </tr>
+        
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Người bán:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%"><a
+                                class="devicecolumn"
+                                href="https://shopee.vn/universal-link/vbinhshop?smtt=580.47822344.7"
+                                style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;"
+                                target="_blank">vbinhshop</a></td>
+                </tr>
+            
+        
+        
+        <tr>
+            <td colspan="2" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;"
+                width="100%">
+                &nbsp;
+            </td>
+        </tr>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+
+        
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        
+        <table width="560" align="center" border="0" cellpadding="0" cellspacing="0" class="devicewidthinner">
+            <tbody>
+            
+            <tr>
+                <td width="560" height="140" align="left" class="devicewidth">
+                    
+                        <a href="https://shopee.vn/universal-link/M%C3%A1y&#43;xay&#43;cafe&#43;c%E1%BA%A7m&#43;tay&#43;c%E1%BB%91i&#43;xay&#43;cafe&#43;mini&#43;Ch%E1%BA%A5t&#43;L%C6%B0%E1%BB%A3ng&#43;c%E1%BB%91i&#43;xay&#43;c%C3%A0&#43;ph%C3%AA&#43;Cao&#43;CNC&#43;6&#43;tr%E1%BB%A5c-i.405225863.23884747599/?smtt=580.47822344.7">
+                            <img src="https://cf.shopee.vn/file/vn-11134207-7r98o-ltaref68c7gka1" alt="" border="0" width="140" height="140" style="display:block; border:none; outline:none; text-decoration:none;" class="col2img">
+                        </a>
+                    
+                </td>
+            </tr>
+            
+            </tbody>
+        </table>
+        
+        
+        <table align="left" border="0" cellpadding="0" cellspacing="0" class="mobilespacing">
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner" style="table-layout:fixed">
+            <tr>
+                <td colspan="2" width="" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+            </tr>
+            <tr>
+                <td colspan="2" style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left">
+                    
+                        1.
+                        
+                            Máy xay cafe cầm tay cối xay cafe mini Chất Lượng cối xay cà phê Cao CNC 6 trục
+                        
+                    
+                </td>
+            </tr>
+
+              
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Mẫu mã: </td>
+                    
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">VBZ18-MàuBạc</td>
+                    
+                </tr>
+                
+                
+                    <tr>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Số lượng: </td>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">1</td>
+                    </tr>
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Giá: </td>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">₫800,000</td>
+                </tr>
+
+             
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+        
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner"
+               style="table-layout:fixed">
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng tiền:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">
+                    ₫800,000
+                </td>
+            </tr>
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Voucher từ Shopee:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">
+                        ₫80,000
+                    </td>
+                </tr>
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Mã giảm giá của Shopee:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">SHOPEE2024VIP
+                    </td>
+                </tr>
+            
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Voucher từ Shop:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">₫50,000
+                    </td>
+                </tr>
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Mã giảm giá của Shop:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">SHOP2024DEAL
+                    </td>
+                </tr>
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Phí vận chuyển:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫0
+                </td>
+            </tr>
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng thanh toán:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫670,000
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            
+            
+        </table>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-weight:bold;font-size: 13px; color: #1f1f1f; text-align:left; line-height: 18px;">
+        BƯỚC TIẾP THEO
+    </td>
+</tr>
+
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Bạn không hài lòng về sản phẩm? <br/>
+        Bạn có thể gửi <a
+                href="https://shopee.vn/universal-link/user/purchase/order/100000000000002/?shopid=405225863&deep_and_deferred=1&smtt=580.47822344.7"
+                style="text-decoration:none;color:#ff5722;">yêu cầu trả hàng</a> trên ứng dụng Shopee trong
+        vòng 3 ngày kể từ khi nhận được email
+        này.<br/><br/>
+
+        Lưu ý: Shopee sẽ từ chối hỗ trợ các khiếu nại sau khi Người mua nhấn "Đã nhận được hàng" trên ứng dụng và Người
+        bán đã nhận được thanh toán cho đơn hàng. <br/><br/>
+
+        Tìm hiểu thêm về chính sách <a
+                href="https://help.shopee.vn/vn/s/topic/0TO6F000000QzKHWA0/tr%E1%BA%A3-h%C3%A0ng-ho%C3%A0n-ti%E1%BB%81n"
+                style="text-decoration:none;color:#ff5722;" target="_blank">Trả hàng/Hoàn tiền</a> của Shopee.
+        <br/><br/>
+        Chúc bạn luôn có những trải nghiệm tuyệt vời khi mua sắm tại Shopee.
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#ffffff"
+                    style="border: 2px solid;border-color: #EE4D2D; padding: 8px 13px 8px 13px; border-radius:3px"
+                    align="center"><a
+                            href="https://shopee.vn/universal-link/user/purchase/order/100000000000002/?shopid=405225863&deep_and_deferred=1&smtt=580.47822344.7"
+                            target="_blank"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #EE4D2D; text-decoration: none; display: inline-block;">
+                        Trả hàng/Hoàn tiền </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+<br/>
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        <br/>
+        Trân trọng,<br/>
+        Đội ngũ Shopee
+    </td>
+</tr>
+
+                                          
+    <tr>
+        <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+            <br/>
+            Bạn có thắc mắc? Liên hệ chúng tôi <a href="https://shopee.vn/universal-link?redir=https%3A%2F%2Fhelp.shopee.vn%2Fportal%3Fsmtt%3D9&smtt=9&deep_and_deferred=1" style="text-decoration:underline!important;color:#ff5722" target="_blank">tại đây</a>.
+        </td>
+    </tr>
+
+                                     
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    
+
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr><td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #747474; text-align:center; line-height: 18px;">
+                                                Hãy mua sắm cùng Shopee
+                                            </td></tr>
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td width="160"></td>
+                                                <td width="130"><a href="https://play.google.com/store/apps/details?id=com.shopee.vn"><img src="https://cf.shopee.sg/file/cacc3e27277d02501b0989fdcbaf18e9" width="130" style="width:130px;"></a></td>
+                                                <td width="5"></td>
+                                                <td width="130"><a href="https://apps.apple.com/vn/app/id959841449"><img src="https://cf.shopee.sg/file/5b4dcec6c9c60950954b465bafee9cff" width="130" style="width:130px;"></a></td>
+                                                <td width="160"></td>
+                                            </tr>
+                                        </table>
+                                        
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:5px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+    </div>
+</div>
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly; text-overflow: ellipsis;color:#ffffff">&nbsp;</td>
+                                        </tr>
+                                        <tr>
+                                            <td width="112" ></td>
+                                            <td width="112" align="center">
+                                                <a href="https://vi-vn.facebook.com/ShopeeVN/"><img src="https://f.shopee.sg/file/3814109aa6a3721b577919d5c8a36cfe" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.instagram.com/shopee_vn/"><img src="https://f.shopee.sg/file/3b08ded58cbbb9beb74ec4d5ad4c7d53" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.youtube.com/channel/UCKcxoGpxOJx3nt83MCG-nuQ"><img src="https://f.shopee.sg/file/e7ab71dae1223ca9eb4b9f120353a31e" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" ></td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:15px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+        &nbsp;
+    </div>
+</div>
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;"><a href="https://shopee.vn/docs/3603" target="_blank" style="text-decoration:none;color:#ff5722">Chính sách bảo mật</a> | <a href="https://shopee.vn/legaldoc/policies/" target="_blank" style="text-decoration:none;color:#ff5722">Điều khoản Shopee</a></td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Đây là email tự động. Vui lòng không trả lời email này. Thêm <a href="mailto:info@mail.shopee.vn" target="_blank" style="text-decoration:none;color:#ff5722">info@mail.shopee.vn</a> vào danh bạ email của bạn để đảm bảo bạn luôn nhận được email từ chúng tôi.</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Tầng 17 Saigon Centre 2, 67 Đường Lê Lợi, Bến Nghé, Quận 1, Hồ Chí Minh 700000, Vietnam</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="40" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+<div style="white-space:nowrap!important;line-height: 0; color: #ffffff;">
+    - - - - - - - - - - - - - - - - - - - - - - - -  - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+</div>
+</body>
+</html>
+

--- a/examples/shopee/test3.html
+++ b/examples/shopee/test3.html
@@ -1,0 +1,1405 @@
+
+
+<!doctype html>
+<html>
+<head>
+    <title>Đơn hàng #2401IJKL345678 đã giao hàng thành công</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+    
+<style type="text/css">
+    .base_font {
+        font-family: Helvetica, arial, sans-serif !important;
+        font-size: 13px;
+        color:#000000;
+    }
+    .orange {
+        color:#ff5722 !important;
+    }
+    .bg_orange {
+        background-color:#ff5722;
+    }
+    .white {
+        color:white;
+    }
+    .caret_right {
+        border-top: 4px solid transparent;
+        border-bottom: 4px solid transparent;
+        border-left: 4px solid white;
+        display: inline-block;
+        height: 0;
+        vertical-align: middle;
+        width: 0;
+    }
+    .text_align_left {
+        text-align: left;
+    }
+    html {
+        --lh: 18px;
+        line-height: var(--lh);
+    }
+    .overflow {
+        --max-lines: 2;
+        position: relative;
+        max-height: calc(var(--lh) * var(--max-lines));
+        min-height: calc(var(--lh) * var(--max-lines));
+        height: calc(var(--lh) * var(--max-lines));
+        overflow: hidden;
+    }
+    .overflow::before {
+        position: absolute;
+        content: "...";
+         
+        bottom: 0;
+        right: 0;
+    }
+    .overflow::after {
+        content: "";
+        position: absolute;
+         
+        right: 0;
+        width: 1rem;
+        height: 1rem;
+    }
+    .link {text-decoration:none;color:#ff5722;}
+
+     
+    div, p, a, li, td { -webkit-text-size-adjust:none; }
+    #outlook a {padding:0;}  
+    html{width: 100%; }
+    body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;}
+     
+    .ExternalClass {width:100%;}  
+    .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}  
+    #backgroundTable {margin:0; padding:0; width:100% !important; line-height: 100% !important;}
+    img {outline:none; text-decoration:none;border:none; -ms-interpolation-mode: bicubic;}
+    a img {border:none;}
+    .image_fix {display:block;}
+    p {margin: 0px 0px !important;}
+    table td {border-collapse: collapse;}
+    table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+    a {color: #33b9ff;text-decoration: none;text-decoration:none!important;}
+     
+    table[class=full] { width: 100%; clear: both; }
+    .textstyle { text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top; width:280px; }
+    .titlestyle { text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold; }
+
+     
+    @media only screen and (max-width: 640px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 440px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 420px!important;text-align:center!important;}
+        .devicecolumn {width:210px;min-width:210px;max-width:210px;}
+        .footercolumn {width:80px;min-width:80px;max-width:80px;display:block!important;}    
+        img[class=banner] {width: 440px!important;height:220px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 132px!important;height:132px!important;}
+
+    }
+     
+     
+    @media only screen and (min-width: 320px) and (max-width: 480px)  and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media only screen and (min-width: 320px) and (max-width: 568px) and (-webkit-min-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+     
+    @media only screen and (min-width: 375px) and (max-width: 667px) and (-webkit-min-device-pixel-ratio: 2){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:157px;min-width:157px;max-width:157px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 95px!important;height:95px!important;}
+
+    }
+     
+    @media only screen and (min-width: 414px) and (max-width: 736px) and (-webkit-min-device-pixel-ratio: 3){
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 110px!important;height:110px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 335px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 315px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;display:block!important;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 335px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio : 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 374px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 354px!important;text-align:center!important;}
+        .devicecolumn {width:177px;min-width:177px;max-width:177px;}
+        .footercolumn {width:70px;min-width:70px;max-width:70px;display:block!important;}    
+        img[class=banner] {width: 374px!important;height:187px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 2) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:320px!important;}
+         
+        img[class=col2img] {width: 160px!important;height:160px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+
+     
+    @media screen and (device-width: 320px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) and (device-height: 740px) and (-webkit-device-pixel-ratio: 4) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:72px!important;}
+    }
+
+     
+    @media screen and (device-width: 360px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 320px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 300px!important;text-align:center!important;}
+        .devicecolumn {width:150px;min-width:150px;max-width:150px;}
+        .footercolumn {width:55px;min-width:55px;max-width:55px;display:block!important;}    
+        img[class=banner] {width: 320px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media only screen and (device-width: 320px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 280px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 260px!important;text-align:center!important;}
+        .devicecolumn {width:130px;min-width:130px;max-width:130px;}
+        .footercolumn {width:50px;min-width:50px;max-width:50px;display:block!important;}    
+        img[class=banner] {width: 280px!important;height:140px!important;}
+         
+        img[class=col2img] {width: 140px!important;height:140px!important;}
+        img[class=col3img] {width: 79px!important;height:79px!important;}
+    }
+
+     
+    @media screen and (device-width: 400px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 360px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 340px!important;text-align:center!important;}
+        .devicecolumn {width:180px;min-width:180px;max-width:180px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 360px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (device-width: 412px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 372px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 352px!important;text-align:center!important;}
+        .devicecolumn {width:186px;min-width:186px;max-width:186px;}
+        .footercolumn {width:65px;min-width:65px;max-width:65px;display:block!important;}    
+        img[class=banner] {width: 372px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+     
+    @media screen and (min-device-width: 392px) and (max-device-width: 393px) {
+        a[href^="tel"], a[href^="sms"] {
+            text-decoration: none;
+            color: #33b9ff;  
+            pointer-events: none;
+            cursor: default;
+        }
+        .mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+            text-decoration: default;
+            color: #33b9ff !important;
+            pointer-events: auto;
+            cursor: default;
+        }
+        table[class=devicewidth] {width: 352px!important;text-align:center!important;}
+        td[class=devicewidth] {padding-left:10px!important;}
+        table[class=devicewidthinner] {width: 332px!important;text-align:center!important;}
+        .devicecolumn {width:176px;min-width:176px;max-width:176px;}
+        .footercolumn {width:60px;min-width:60px;max-width:60px;display:block!important;}    
+        img[class=banner] {width: 352px!important;height:130px!important;}
+         
+        img[class=col2img] {width: 130px!important;height:130px!important;}
+        img[class=col3img] {width: 100px!important;height:100px!important;}
+    }
+
+</style>
+
+</head>
+<body><img alt="" src="https://tracking.mail.shopee.vn/tracking/1/open/sYqLcitb07BhEzfjKz6aTCkLYYBmONzwC7onlFrY-PvFbImPOwszV9TBUCF4G9cPOf_Sw39cqFf4budHLfMiVAShCzgPDuqfoXO_hblSZbmKad2Tqm5giQ023dDon2D2F4E1ZA5kaGRBcHkfPdIoWGkrQOfUFCB4XvSuw1qK7gGlPrkOhHeR6ORRiKGr96aw2Ho-PjXVd26349JdglWVJsCKUkR2hRyWugz4VlFeaeEacYsnz7hAjZMGymua0zHW5Wppz127-Rmzrr2cNLMASAdRt9MSTVGUd-h0kujAIpNr8i3j8MQabuhTsfvwPy6Ey82rYAcG8yWQhelWozI_Ir1V-kuw7zgwYaFRMUbLk7Yc8Ka6SWwPTdFH4STt2xLe88eLFmDNfV26PBp3XcKxrVHjVFDyA8OS7DEp4fmw-0NrMk-lrw_m5qZT2Kl-SJ8SGD9hYrxEbpRpC4QQR6zeHPLurPT7LrQlOOceGMDFnCKLrYYcpj6vYL2Vb97nvciZV_PRRUYPLUe6iHDhAskdiP4d75E4K-HHX8iWQ9hdfFz7oa04k4appzIkDOha3gmHmi6RXOVVnXPKmd9hNbPqxYsOEqq5Xfd8ELpATFHSyA0=" width="1" height="1">
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td align="center"><img src="https://cf.shopee.sg/file/0cd023d64f04491f3dc8076d6932dfdc" width="140" height="auto" style="width: 25%;height: auto;"></td>
+                                        </tr>
+                                        
+                                        
+                                        
+                                        <tr>
+                                            <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        Xin chào carol_le,
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Đơn hàng <a
+                href="https://shopee.vn/universal-link/user/purchase/order/100000000000003/?shopid=601622525&deep_and_deferred=1&smtt=580.47822344.7"
+                target="_blank" style="text-decoration:none;color:#ff5722">#2401IJKL345678</a> của bạn đã được giao thành
+        công ngày 03/01/2024. <br/><br/>
+        Vui lòng đăng nhập Shopee để xác nhận bạn đã nhận hàng và hài lòng với sản phẩm trong
+        vòng 3 ngày. Sau khi bạn xác nhận, chúng tôi sẽ
+        thanh toán cho Người bán <a
+                href="https://shopee.vn/universal-link/mujivn.official?smtt=580.47822344.7"
+                target="_blank" style="text-decoration:none;color:#ff5722">mujivn.official</a>.
+        <br/>
+        Nếu bạn không xác nhận trong khoảng thời gian này, Shopee cũng sẽ thanh toán cho Người bán.
+
+    </td>
+</tr>
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#EE4D2D" style="padding: 8px 30px 8px 30px; border-radius:3px" align="center"><a
+                            href="https://shopee.vn/universal-link/user/purchase/order/100000000000003/?shopid=601622525&deep_and_deferred=1&smtt=580.47822344.7"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; display: inline-block;">
+                        Đã nhận hàng </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+
+    
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+    
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif;  color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+    </tr>
+    <tr>
+        <td colspan="2"
+            style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size: 13px;font-weight:bold;">
+            THÔNG TIN ĐƠN HÀNG - DÀNH CHO NGƯỜI MUA
+        </td>
+    </tr>
+    
+    
+    <tr>
+        <td height="" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;" width="100%">&nbsp;</td>
+    </tr>
+    
+    
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+    
+
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Mã đơn hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">
+                
+                    <a class="devicecolumn" href="https://shopee.vn/universal-link/user/purchase/order/100000000000003/?shopid=601622525&deep_and_deferred=1&smtt=580.47822344.7"
+                       style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;" target="_blank">#2401IJKL345678</a>
+                
+            </td>
+        </tr>
+        <tr>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">Ngày đặt hàng:
+            </td>
+            <td class="devicecolumn"
+                style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                width="49%">01/01/2024 00:00:00
+            </td>
+        </tr>
+        
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Người bán:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%"><a
+                                class="devicecolumn"
+                                href="https://shopee.vn/universal-link/mujivn.official?smtt=580.47822344.7"
+                                style="text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#ff5722;vertical-align:top; width:280px;"
+                                target="_blank">mujivn.official</a></td>
+                </tr>
+            
+        
+        
+        <tr>
+            <td colspan="2" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;"
+                width="100%">
+                &nbsp;
+            </td>
+        </tr>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+
+        
+    
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        
+        <table width="560" align="center" border="0" cellpadding="0" cellspacing="0" class="devicewidthinner">
+            <tbody>
+            
+            <tr>
+                <td width="560" height="140" align="left" class="devicewidth">
+                    
+                        <a href="https://shopee.vn/universal-link/%C3%81o&#43;Kho%C3%A1c&#43;Hoodie&#43;Nam&#43;Kh%C3%B3a&#43;K%C3%A9o&#43;G%E1%BA%A5p&#43;G%E1%BB%8Dn&#43;Ch%E1%BB%91ng&#43;Tia&#43;Uv&#43;Nhanh&#43;Kh%C3%B4&#43;MUJI-i.601622525.28386292086/?smtt=580.47822344.7">
+                            <img src="https://cf.shopee.vn/file/vn-11134207-7ra0g-m9gush78k9ymf5" alt="" border="0" width="140" height="140" style="display:block; border:none; outline:none; text-decoration:none;" class="col2img">
+                        </a>
+                    
+                </td>
+            </tr>
+            
+            </tbody>
+        </table>
+        
+        
+        <table align="left" border="0" cellpadding="0" cellspacing="0" class="mobilespacing">
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner" style="table-layout:fixed">
+            <tr>
+                <td colspan="2" width="" height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+            </tr>
+            <tr>
+                <td colspan="2" style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left">
+                    
+                        1.
+                        
+                            Áo Khoác Hoodie Nam Khóa Kéo Gấp Gọn Chống Tia Uv Nhanh Khô MUJI
+                        
+                    
+                </td>
+            </tr>
+
+              
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Mẫu mã: </td>
+                    
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Xám nhạt,M</td>
+                    
+                </tr>
+                
+                
+                    <tr>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Số lượng: </td>
+                        <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">1</td>
+                    </tr>
+                
+                <tr>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">Giá: </td>
+                    <td style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;" width="49%" class="devicecolumn">₫500,000</td>
+                </tr>
+
+             
+            
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+        </table>
+        
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+        
+        
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+        <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner"
+               style="table-layout:fixed">
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif; color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng tiền:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">
+                    ₫500,000
+                </td>
+            </tr>
+            
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Voucher từ Shopee:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">
+                        ₫50,000
+                    </td>
+                </tr>
+                <tr>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">Mã giảm giá của Shopee:
+                    </td>
+                    <td class="devicecolumn"
+                        style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                        width="49%">SPEE2024SAVE
+                    </td>
+                </tr>
+            
+            
+
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Phí vận chuyển:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫0
+                </td>
+            </tr>
+            <tr>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">Tổng thanh toán:
+                </td>
+                <td class="devicecolumn"
+                    style="word-break:break-word;text-align:left;font-family: Helvetica, arial, sans-serif;font-size: 13px;color:#000000;vertical-align:top;"
+                    width="49%">₫450,000
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            <tr>
+                <td colspan="2"
+                    style="text-align:left;font-family: Helvetica, arial, sans-serif;color:#1f1f1f; font-size:16px;font-weight:bold;height:10px;"></td>
+            </tr>
+            
+            
+            
+        </table>
+        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+        
+        
+    <div style="width:100%; height:1px;display:block;" align="center">
+        <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;"></div>
+    </div>
+
+    
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-weight:bold;font-size: 13px; color: #1f1f1f; text-align:left; line-height: 18px;">
+        BƯỚC TIẾP THEO
+    </td>
+</tr>
+
+
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+
+
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+
+        Bạn không hài lòng về sản phẩm? <br/>
+        Bạn có thể gửi <a
+                href="https://shopee.vn/universal-link/user/purchase/order/100000000000003/?shopid=601622525&deep_and_deferred=1&smtt=580.47822344.7"
+                style="text-decoration:none;color:#ff5722;">yêu cầu trả hàng</a> trên ứng dụng Shopee trong
+        vòng 3 ngày kể từ khi nhận được email
+        này.<br/><br/>
+
+        Lưu ý: Shopee sẽ từ chối hỗ trợ các khiếu nại sau khi Người mua nhấn "Đã nhận được hàng" trên ứng dụng và Người
+        bán đã nhận được thanh toán cho đơn hàng. <br/><br/>
+
+        Tìm hiểu thêm về chính sách <a
+                href="https://help.shopee.vn/vn/s/topic/0TO6F000000QzKHWA0/tr%E1%BA%A3-h%C3%A0ng-ho%C3%A0n-ti%E1%BB%81n"
+                style="text-decoration:none;color:#ff5722;" target="_blank">Trả hàng/Hoàn tiền</a> của Shopee.
+        <br/><br/>
+        Chúc bạn luôn có những trải nghiệm tuyệt vời khi mua sắm tại Shopee.
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+<tr>
+    <td colspan="2">
+        <table border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <td bgcolor="#ffffff"
+                    style="border: 2px solid;border-color: #EE4D2D; padding: 8px 13px 8px 13px; border-radius:3px"
+                    align="center"><a
+                            href="https://shopee.vn/universal-link/user/purchase/order/100000000000003/?shopid=601622525&deep_and_deferred=1&smtt=580.47822344.7"
+                            target="_blank"
+                            style="font-size: 14px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #EE4D2D; text-decoration: none; display: inline-block;">
+                        Trả hàng/Hoàn tiền </a></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+
+    <tr>
+        <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+    </tr>
+
+
+
+<br/>
+<tr>
+    <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+        <br/>
+        Trân trọng,<br/>
+        Đội ngũ Shopee
+    </td>
+</tr>
+
+                                          
+    <tr>
+        <td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #000000; text-align:left; line-height: 18px;">
+            <br/>
+            Bạn có thắc mắc? Liên hệ chúng tôi <a href="https://shopee.vn/universal-link?redir=https%3A%2F%2Fhelp.shopee.vn%2Fportal%3Fsmtt%3D9&smtt=9&deep_and_deferred=1" style="text-decoration:underline!important;color:#ff5722" target="_blank">tại đây</a>.
+        </td>
+    </tr>
+
+                                     
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="100%" height="1" bgcolor="#ffffff" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+
+    
+
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            
+                            <tr>
+                                <td height="20" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                            </tr>
+                            
+
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        <tr><td style="font-family: Helvetica, arial, sans-serif; font-size: 13px; color: #747474; text-align:center; line-height: 18px;">
+                                                Hãy mua sắm cùng Shopee
+                                            </td></tr>
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td width="160"></td>
+                                                <td width="130"><a href="https://play.google.com/store/apps/details?id=com.shopee.vn"><img src="https://cf.shopee.sg/file/cacc3e27277d02501b0989fdcbaf18e9" width="130" style="width:130px;"></a></td>
+                                                <td width="5"></td>
+                                                <td width="130"><a href="https://apps.apple.com/vn/app/id959841449"><img src="https://cf.shopee.sg/file/5b4dcec6c9c60950954b465bafee9cff" width="130" style="width:130px;"></a></td>
+                                                <td width="160"></td>
+                                            </tr>
+                                        </table>
+                                        
+                                        <tr>
+                                            <td width="100%" height="5" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:5px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+    </div>
+</div>
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly; text-overflow: ellipsis;color:#ffffff">&nbsp;</td>
+                                        </tr>
+                                        <tr>
+                                            <td width="112" ></td>
+                                            <td width="112" align="center">
+                                                <a href="https://vi-vn.facebook.com/ShopeeVN/"><img src="https://f.shopee.sg/file/3814109aa6a3721b577919d5c8a36cfe" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.instagram.com/shopee_vn/"><img src="https://f.shopee.sg/file/3b08ded58cbbb9beb74ec4d5ad4c7d53" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" align="center">
+                                                <a href="https://www.youtube.com/channel/UCKcxoGpxOJx3nt83MCG-nuQ"><img src="https://f.shopee.sg/file/e7ab71dae1223ca9eb4b9f120353a31e" width="40" style="height: 40px; width: 40px"/></a>
+                                            </td>
+                                            <td width="112" ></td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="5" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<div style="width:100%; height:15px;display:block;" align="center">
+    <div style="width:100%;max-width:600px;height:1px;border-top:1px solid #e0e0e0;">
+        &nbsp;
+    </div>
+</div>
+
+
+
+<table width="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0" border="0" id="backgroundTable" st-sortable="full-text">
+    <tbody>
+    <tr>
+        <td>
+            <table width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                <tbody>
+                <tr>
+                    <td width="100%">
+                        <table bgcolor="#ffffff" width="600" cellpadding="0" cellspacing="0" border="0" align="center" class="devicewidth">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table width="560" align="center" cellpadding="0" cellspacing="0" border="0" class="devicewidthinner">
+                                        <tbody>
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;"><a href="https://shopee.vn/docs/3603" target="_blank" style="text-decoration:none;color:#ff5722">Chính sách bảo mật</a> | <a href="https://shopee.vn/legaldoc/policies/" target="_blank" style="text-decoration:none;color:#ff5722">Điều khoản Shopee</a></td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Đây là email tự động. Vui lòng không trả lời email này. Thêm <a href="mailto:info@mail.shopee.vn" target="_blank" style="text-decoration:none;color:#ff5722">info@mail.shopee.vn</a> vào danh bạ email của bạn để đảm bảo bạn luôn nhận được email từ chúng tôi.</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="10" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+
+                                        <tr>
+                                            <td style="font-family: Helvetica, arial, sans-serif;  font-size: 11px; color: #747474; text-align:center; line-height: 100%;">Tầng 17 Saigon Centre 2, 67 Đường Lê Lợi, Bến Nghé, Quận 1, Hồ Chí Minh 700000, Vietnam</td>
+                                        </tr>
+
+                                        
+                                        <tr>
+                                            <td width="100%" height="40" style="font-size:1px; line-height:1px; mso-line-height-rule: exactly;">&nbsp;</td>
+                                        </tr>
+                                        
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+<div style="white-space:nowrap!important;line-height: 0; color: #ffffff;">
+    - - - - - - - - - - - - - - - - - - - - - - - -  - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+</div>
+</body>
+</html>
+

--- a/llms.txt
+++ b/llms.txt
@@ -53,9 +53,14 @@ Return variable schema without extracting. Each item:
 ```python
 {"name": "amount", "type": "float", "kind": "extract"}
 {"name": "bank",   "type": "str",   "kind": "static_assign", "value": "Vietcombank"}
+# List blocks:
+{"name": "item", "type": "list", "kind": "list", "fields": [
+    {"name": "name", "type": "str", "kind": "extract"},
+    {"name": "price", "type": "float", "kind": "extract"},
+]}
 ```
 
-Fields: name (dotted path), type (str/int/float/date/datetime), kind (extract|static_assign), value (only when kind==static_assign).
+Fields: name (dotted path), type (str/int/float/date/datetime/list), kind (extract|static_assign|list), value (only when kind==static_assign), fields (only when kind==list — field descriptors for list items).
 
 ### Exceptions
 
@@ -98,10 +103,27 @@ except CoercionError as e:
 
 Adds a hard-coded field to the result dict. Supports single-quoted strings, int, float, and true/false literals.
 
+### List blocks (dynamic repeated content)
+
+```
+{% list: item %}
+- {{ item.name }} x{{ item.quantity:int }} - ${{ item.price:float }}
+{% end %}
+```
+
+- Extracts a variable-length list of structured items from repeated content (e.g. order line items).
+- `item` is the collection name — appears as a key in the result dict with a `list[dict]` value.
+- Variables inside the block must be prefixed with the collection name (`item.name`, `item.price`, etc.).
+- All coercion types are supported inside the block.
+- If no items are found, the collection is set to `[]`.
+- Nested list blocks raise `TemplateParseError`.
+- `stop_on_filled` cannot reference loop-body variables (raises `ValueError`).
+
 ### Constraints
 
 - Two `{{ }}` variables cannot be adjacent — at least one literal character must separate them.
 - Type annotations must be one of: str, int, float, date, datetime.
+- Nested `{% list: … %}` blocks are not supported.
 
 ## Type coercion
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docthu"
-version = "0.5.3"
+version = "0.6.0"
 description = "Template-based structured data extraction from emails and text messages"
 requires-python = ">=3.10"
 dependencies = ["streamlit>=1.35"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -346,12 +346,12 @@ def test_assignment_float_literal_type_in_variables():
 # ---------------------------------------------------------------------------
 
 def test_invalid_block_raises():
-    with pytest.raises(TemplateParseError, match="Invalid assignment syntax"):
+    with pytest.raises(TemplateParseError, match="Invalid block syntax"):
         parse("{% invalid syntax here %}\nDate: {{ date }}", "Date: 2024-01-01")
 
 
 def test_block_missing_equals_raises():
-    with pytest.raises(TemplateParseError, match="Invalid assignment syntax"):
+    with pytest.raises(TemplateParseError, match="Invalid block syntax"):
         parse("{% no_equals 'value' %}\nHello", "Hello")
 
 
@@ -427,3 +427,126 @@ def test_stop_on_filled_trailing_static_differs():
     )
     result = parse(template, message, stop_on_filled=["receipt_number"])
     assert result == {"receipt_number": "ABC-999"}
+
+
+# ---------------------------------------------------------------------------
+# 17. {% list: name %} / {% end %} — dynamic list extraction
+# ---------------------------------------------------------------------------
+
+ORDER_TEMPLATE = """\
+Order #{{ order_number }}
+
+Items:
+{% list: item %}
+- {{ item.name }} x{{ item.quantity:int }} - ${{ item.price:float }}
+{% end %}
+Subtotal: ${{ subtotal:float }}
+Total: ${{ total:float }}
+"""
+
+ORDER_MESSAGE_3 = """\
+Order #ORD-12345
+
+Items:
+- Widget A x2 - $9.99
+- Widget B x1 - $24.99
+- Widget C x3 - $4.99
+
+Subtotal: $49.94
+Total: $54.93
+"""
+
+ORDER_MESSAGE_1 = """\
+Order #ORD-00001
+
+Items:
+- Only Thing x1 - $99.00
+
+Subtotal: $99.00
+Total: $99.00
+"""
+
+
+def test_list_basic_multiple_items():
+    result = parse(ORDER_TEMPLATE, ORDER_MESSAGE_3)
+    assert result["order_number"] == "ORD-12345"
+    assert len(result["item"]) == 3
+    assert result["item"][0] == {"name": "Widget A", "quantity": 2, "price": 9.99}
+    assert result["item"][1] == {"name": "Widget B", "quantity": 1, "price": 24.99}
+    assert result["item"][2] == {"name": "Widget C", "quantity": 3, "price": 4.99}
+    assert result["subtotal"] == 49.94
+    assert result["total"] == 54.93
+
+
+def test_list_single_item():
+    result = parse(ORDER_TEMPLATE, ORDER_MESSAGE_1)
+    assert result["order_number"] == "ORD-00001"
+    assert len(result["item"]) == 1
+    assert result["item"][0] == {"name": "Only Thing", "quantity": 1, "price": 99.00}
+
+
+def test_list_zero_items():
+    template = "Items:\n{% list: item %}\n- {{ item.name }}\n{% end %}\nDone"
+    message = "Items:\nDone"
+    result = parse(template, message)
+    assert result["item"] == []
+
+
+def test_list_template_reuse():
+    tpl = Template(ORDER_TEMPLATE)
+    r1 = tpl.match(ORDER_MESSAGE_3)
+    r2 = tpl.match(ORDER_MESSAGE_1)
+    assert len(r1["item"]) == 3
+    assert len(r2["item"]) == 1
+
+
+def test_list_variables_schema():
+    schema = variables(ORDER_TEMPLATE)
+    list_entry = next(e for e in schema if e["kind"] == "list")
+    assert list_entry["name"] == "item"
+    assert list_entry["type"] == "list"
+    fields = {f["name"]: f["type"] for f in list_entry["fields"]}
+    assert fields == {"name": "str", "quantity": "int", "price": "float"}
+
+
+def test_list_with_outer_assignment():
+    template = """\
+{% store = 'ACME' %}
+Receipt:
+{% list: line %}
+{{ line.desc }} ${{ line.amount:float }}
+{% end %}
+"""
+    message = """\
+Receipt:
+Coffee $3.50
+Tea $2.00
+"""
+    result = parse(template, message)
+    assert result["store"] == "ACME"
+    assert len(result["line"]) == 2
+    assert result["line"][0] == {"desc": "Coffee", "amount": 3.50}
+    assert result["line"][1] == {"desc": "Tea", "amount": 2.00}
+
+
+def test_nested_list_raises():
+    with pytest.raises(TemplateParseError, match="Nested"):
+        parse(
+            "{% list: outer %}\n{% list: inner %}\n{{ inner.x }}\n{% end %}\n{% end %}",
+            "anything",
+        )
+
+
+def test_end_without_list_raises():
+    with pytest.raises(TemplateParseError, match="without a matching"):
+        parse("Hello\n{% end %}\nWorld", "Hello World")
+
+
+def test_unclosed_list_raises():
+    with pytest.raises(TemplateParseError, match="Unclosed"):
+        parse("{% list: item %}\n{{ item.x }}", "x")
+
+
+def test_stop_on_filled_rejects_loop_var():
+    with pytest.raises(ValueError, match="loop-body variables"):
+        parse(ORDER_TEMPLATE, ORDER_MESSAGE_3, stop_on_filled=["item.name"])


### PR DESCRIPTION
## Summary

Adds support for extracting variable-length repeated structures from templates — the core missing capability for real-world emails like shopping order confirmations where the number of line items is unknown at template-write time.

### New syntax

```
{% list: item %}
- {{ item.name }} x{{ item.quantity:int }} - ${{ item.price:float }}
{% end %}
```

`item` is both the collection name (key in the result dict) and the object prefix for field placeholders inside the block. The result is a `list[dict]` where each dict holds the fields relative to the prefix.

### How it works (two-phase matching)

Python's `re` module does not allow repeated named groups, so a single-regex approach is not possible. Instead:

1. **Phase 1 — main regex**: the list region is captured as a single blob group (`(?P<__list_item>[\s\S]*?)`), bounded by the surrounding literal anchors.  
2. **Phase 2 — `finditer`**: a compiled body sub-pattern (derived from the loop body tokens) is applied to the blob to extract each item as a dict.

### What changed

| File | Change |
|---|---|
| `docthu/tokenizer.py` | New `ListToken` and `EndToken` dataclasses; updated scanner and post-parse validation |
| `docthu/matcher.py` | New `LoopSpec` / `CompiledTemplate` dataclasses; `_split_loop_blocks`, `_outer_tokens`, `_loop_var_names` helpers; two-phase `extract()`; `compile_tokens()` returns `CompiledTemplate` instead of bare `re.Pattern` |
| `docthu/__init__.py` | `_variables()` emits `kind="list"` entries with `fields`; `Template` docstrings updated |
| `tests/test_basic.py` | 10 new test cases (basic list, single item, zero items, template reuse, schema, nested-list error, end-without-list error, unclosed-list error, `stop_on_filled` rejection); two existing tests updated for changed error message |
| `docs/api.md` | List blocks section with full syntax reference, example, and `variables()` schema |
| `llms.txt` | Machine-readable summary updated with list block syntax and schema |

### Constraints and edge cases

| Case | Behaviour |
|---|---|
| Zero items | Blob captured as empty string → `[]` (uses `*` quantifier) |
| Nested `{% list: … %}` | `TemplateParseError` |
| `{% end %}` without matching `{% list: … %}` | `TemplateParseError` |
| Unclosed `{% list: … %}` | `TemplateParseError` |
| `stop_on_filled` referencing a loop-body variable | `ValueError` |
| Dotted field names inside loop (`item.address.city`) | Produces nested dict in each item |

## Test plan

- [x] `pytest tests/` — 51 tests, all passing
- [x] Manual end-to-end: Shopee order delivery HTML emails (`test1.html`, `test2.html`, `test3.html`) — 2-item order, 1-item with vouchers, 1-item with single voucher all extract correctly with a single `template.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)